### PR TITLE
修正QRun传递参数包含空白时，传递不完整的问题

### DIFF
--- a/lib/lib_clQ.ahk
+++ b/lib/lib_clQ.ahk
@@ -1408,7 +1408,7 @@ qrunBy(_exe, _paramStr:="", ifAdmin:=false)
                 if(ifAdmin && !RegExMatch(t, "i)^\*RunAs\s"))
                     t:="*RunAs " . t
                 if(_paramStr)
-                    t:=t . " " . _paramStr
+                    t:=t . " """ . _paramStr . """"
                 run, % t
             }
             else


### PR DESCRIPTION
就是加个引号