### PR TITLE
Add Esc key function.

### DIFF
--- a/lib/lib_keysFunction.ahk
+++ b/lib/lib_keysFunction.ahk
@@ -21,6 +21,11 @@ keyFunc_run(p){
     return
 }
 
+keyFunc_esc(){
+    SendInput, {Esc}
+    return
+}
+
 keyFunc_mouseSpeedIncrease(){
     global
     mouseSpeed+=1


### PR DESCRIPTION
The "Esc" key becomes quite far away from the frequently used keyboard area after having Capslock+.
Shall we add a key function for the "Esc" key so that users can map it as they like?