### PR TITLE
update: add hotkey for number 0-9

### DIFF
--- a/CapsLock+.ahk
+++ b/CapsLock+.ahk
@@ -245,6 +245,66 @@ try
 Capslock2:=""
 return
 
+` & space::
+try
+    keyFunc_send(0)
+Capslock2:=""
+return
+
+` & n::
+try
+    keyFunc_send(1)
+Capslock2:=""
+return
+
+` & m::
+try
+    keyFunc_send(2)
+Capslock2:=""
+return
+
+` & ,::
+try
+    keyFunc_send(3)
+Capslock2:=""
+return
+
+` & h::
+try
+    keyFunc_send(4)
+Capslock2:=""
+return
+
+
+` & j::
+try
+    keyFunc_send(5)
+Capslock2:=""
+return
+
+` & k::
+try
+    keyFunc_send(6)
+Capslock2:=""
+return
+
+` & y::
+try
+    keyFunc_send(7)
+Capslock2:=""
+return
+
+` & u::
+try
+    keyFunc_send(8)
+Capslock2:=""
+return
+
+` & i::
+try
+    keyFunc_send(9)
+Capslock2:=""
+return
 
 -::
 try

--- a/CapsLock+.ahk
+++ b/CapsLock+.ahk
@@ -306,6 +306,18 @@ try
 Capslock2:=""
 return
 
+` & backspace::
+try
+    runFunc(keyset.caps_w)
+Capslock2:=""
+return
+    
+` & .::
+try
+    SendInput, {U+002e}
+Capslock2:=""
+return
+
 -::
 try
     runFunc(keyset.caps_minus)


### PR DESCRIPTION
默认的配置中caps+\` 无操作，将反引号\`认为修饰键，caps+\` 再按下[space | n | m | , | h | j | k | y | u | i ] 可输入数字0-9，缓解了无小键盘输入数字的问题