### PR TITLE
实现Caps+滚轮

### DIFF
--- a/CapsLock+.ahk
+++ b/CapsLock+.ahk
@@ -164,6 +164,18 @@ try
 Capslock2:=""
 return
 
+<WheelUp::
+try
+    runFunc(keyset.caps_wheelUp)
+Capslock2:=""
+return
+
+<WheelDown::
+try
+    runFunc(keyset.caps_wheelDown)
+Capslock2:=""
+return
+
 ;--::-------------------------
 ;  KEY_TO_NAME := {"a":"a","b":"b","c":"c","d":"d","e":"e","f":"f","g":"g","h":"h","i":"i"
 ;    ,"j":"j","k":"k","l":"l","m":"m","n":"n","o":"o","p":"p","q":"q","r":"r"

--- a/language/English.ahk
+++ b/language/English.ahk
@@ -674,6 +674,10 @@ caps_lalt_wheelUp=keyFunc_doNothing
 
 caps_lalt_wheelDown=keyFunc_doNothing
 
+caps_wheelUp=keyFunc_doNothing
+
+caps_wheelDown=keyFunc_doNothing
+
 ; CapsLock + Windows + 0~9 -> Bind window 0~9
 caps_win_1=keyFunc_winbind_binding(1)
 

--- a/language/Simplified_Chinese.ahk
+++ b/language/Simplified_Chinese.ahk
@@ -646,6 +646,10 @@ caps_lalt_wheelUp=keyFunc_doNothing
 
 caps_lalt_wheelDown=keyFunc_doNothing
 
+caps_wheelUp=keyFunc_doNothing
+
+caps_wheelDown=keyFunc_doNothing
+
 ; CapsLock + Windows + 0~9 -> 绑定窗口 0~9
 caps_win_1=keyFunc_winbind_binding(1)
 
@@ -722,6 +726,12 @@ keyfunc_wheel_up
 
 ; 滚轮下滑
 keyfunc_wheel_down
+
+; 左滑滚轮
+keyFunc_wheel_left
+
+; 右滑滚轮
+keyFunc_wheel_right
 
 )
 global lang_winsInfosRecorderIniInit:=""

--- a/lib/lib_keysFunction.ahk
+++ b/lib/lib_keysFunction.ahk
@@ -862,6 +862,15 @@ keyfunc_wheel_down(){
     Send, {Wheeldown 3}
 }
 
+; 左滑滚轮
+keyFunc_wheelLeft(){
+    Send, {WheelLeft}
+}
+
+; 右滑滚轮
+keyFunc_wheelRight(){
+    Send, {WheelRight}
+}
 
 ;keys functions end-------------
 

--- a/lib/lib_keysSet.ahk
+++ b/lib/lib_keysSet.ahk
@@ -551,6 +551,10 @@ keySchemeInit_capslockPlus(){
     if(!keyset.caps_lalt_wheelDown)
         keyset.caps_lalt_wheelDown:="keyFunc_mouseSpeedDecrease"
 
+    if(!keyset.caps_wheelUp)
+        keyset.caps_wheelUp:="keyFunc_doNothing"
+    if(!keyset.caps_wheelDown)
+        keyset.caps_wheelDown:="keyFunc_doNothing"
 
 
     return

--- a/lib/lib_keysSet.ahk
+++ b/lib/lib_keysSet.ahk
@@ -290,6 +290,11 @@ keySchemeInit_capslox(){
         keyset.caps_lalt_wheelUp:="keyFunc_mouseSpeedIncrease"
     if(!keyset.caps_lalt_wheelDown)
         keyset.caps_lalt_wheelDown:="keyFunc_mouseSpeedDecrease"
+    if(!keyset.caps_wheelUp)
+        keyset.caps_wheelUp:="keyFunc_doNothing"
+    if(!keyset.caps_wheelDown)
+        keyset.caps_wheelDown:="keyFunc_doNothing"
+
 
     return
 }
@@ -550,7 +555,6 @@ keySchemeInit_capslockPlus(){
         keyset.caps_lalt_wheelUp:="keyFunc_mouseSpeedIncrease"
     if(!keyset.caps_lalt_wheelDown)
         keyset.caps_lalt_wheelDown:="keyFunc_mouseSpeedDecrease"
-
     if(!keyset.caps_wheelUp)
         keyset.caps_wheelUp:="keyFunc_doNothing"
     if(!keyset.caps_wheelDown)


### PR DESCRIPTION
因为合并冲突, #156 挪到这里。

代码来自#126。整合了一下，加到了设置示例里面。

关于命名，有一点疑问，上面的`keyfunc_wheel_up`，并未采用驼峰法：
https://github.com/wo52616111/capslock-plus/blob/eef0e0261542aeeac417d42b179a044e69428561/lib/lib_keysFunction.ahk#L856-L859