### PR TITLE
新增：翻译APItype=2，调用openAI SDK 使用LLM翻译

### DIFF
--- a/CapsLock+.ahk
+++ b/CapsLock+.ahk
@@ -318,6 +318,12 @@ try
 Capslock2:=""
 return
 
+'::
+try
+    SendInput, {U+005c}
+Capslock2:=""
+return
+
 -::
 try
     runFunc(keyset.caps_minus)
@@ -354,13 +360,6 @@ try
     runFunc(keyset.caps_semicolon)
 Capslock2:=""
 Return
-
-'::
-try
-    runFunc(keyset.caps_quote)
-Capslock2:=""
-return
-
 
 ,::
 try
@@ -892,6 +891,40 @@ return
 #If
 
 
+;---------------------自定义脚本----------------
+
+; 在文件末尾的 #If 指令之前添加以下代码
+global F12State
+global F12Timer 
+
+F12::
+    F12Timer:=F12State := 1
+
+    SetTimer, setF12Timer, -300  ; 启动 300ms 计时器
+    KeyWait, F12
+    F12State := ""
+
+    if (F12Timer) {  ; 300ms 过后 F12Timer 仍为 0，说明没有按其他键
+        SetTimer, setF12Timer, Off
+        SendInput, {F12}  ; 发送原始 F12
+    }
+    return
+
+setF12Timer:
+    F12Timer := ""  ; 标记 F12 长按超过 300ms
+    return
+
+#If (F12State = 1)  ; 当 F12 按下时启用以下热键
+
+Delete::
+    SetTimer, setF12Timer, Off  ; 停止定时器，防止 F12 触发
+    Run, "D:\Apps\A-scripts\sleep2"  ; 运行批处理文件
+    ; Run, "D:\Apps\PSTools\psshutdown.exe -d -t 0"
+    F12State := ""  ; 复位状态
+    F12Timer := ""
+    return
+
+#If  ; 结束条件编译
 
 
 GuiClose:

--- a/CapsLock+.ahk
+++ b/CapsLock+.ahk
@@ -245,6 +245,66 @@ try
 Capslock2:=""
 return
 
+` & space::
+try
+    keyFunc_send(0)
+Capslock2:=""
+return
+
+` & n::
+try
+    keyFunc_send(1)
+Capslock2:=""
+return
+
+` & m::
+try
+    keyFunc_send(2)
+Capslock2:=""
+return
+
+` & ,::
+try
+    keyFunc_send(3)
+Capslock2:=""
+return
+
+` & h::
+try
+    keyFunc_send(4)
+Capslock2:=""
+return
+
+
+` & j::
+try
+    keyFunc_send(5)
+Capslock2:=""
+return
+
+` & k::
+try
+    keyFunc_send(6)
+Capslock2:=""
+return
+
+` & y::
+try
+    keyFunc_send(7)
+Capslock2:=""
+return
+
+` & u::
+try
+    keyFunc_send(8)
+Capslock2:=""
+return
+
+` & i::
+try
+    keyFunc_send(9)
+Capslock2:=""
+return
 
 -::
 try

--- a/CapsLock+.ahk
+++ b/CapsLock+.ahk
@@ -306,6 +306,18 @@ try
 Capslock2:=""
 return
 
+` & backspace::
+try
+    runFunc(keyset.caps_w)
+Capslock2:=""
+return
+    
+` & .::
+try
+    SendInput, {U+002e}
+Capslock2:=""
+return
+
 -::
 try
     runFunc(keyset.caps_minus)

--- a/language/English.ahk
+++ b/language/English.ahk
@@ -28,6 +28,11 @@ global lang_yd_dict:=   "------------------------------ Youdao dictionary ------
 global lang_yd_phrase:= "----------------------------------- Phrase ------------------------------------"
 global lang_yd_free_key_unavailable_warning:="Youdao Translate no longer provides free translation API, now you can only use the paid API (new accounts have a trial amount), please refer to the instructions in the [TTranslate] section of the CapsLock+settingsDemo.ini file to set up the key and use the translation function."
 
+global lang_openai_name:="LLM Translation"
+global lang_openai_errorConfig:="lack of OpenAI API configuration [Url,Key,Model,Prompt], LLM translation cannot be used"
+global lang_openai_errorNoNet:="Error on sending request, maybe the network is disconnected"
+global lang_openai_errorNoResults:="No translation results, the network may be disconnected or the text is too long"
+
 global lang_settingsFileContent:=""
 lang_settingsFileContent=
 (
@@ -281,18 +286,26 @@ progressColor=0x00cc99
 ; ## +T Translation settings (Chinese <-> English)
 
 [TTranslate]
+; Translation API type, currently can only be 1 or 2
+; 0: Free version of Youdao API (no longer available, no longer provided by Youdao)
+; 1: Paid version of Youdao API (default value)
+apiType=1
+
+;>>>>>>
+;Parameters for OpenAI API 
+openaiUrl=https://api.openai.com/v1/chat/completions
+openaiKey=abc
+openaiModel=gpt-4o
+openaiPrompt="Translate the given text into Chinese. If the text to be translated is a word, please provide a detailed explanation of that word."
+;<<<<<<
+
+;>>>>>>
+; Parameters for paid version Youdao application
 ; About Youdao API
 ; The translation function is implemented by calling Youdao API.
 
 ; Youdao's paid version API website: https://ai.youdao.com/console/#/
 ; Getting started docs about Youdao's API: https://ai.youdao.com/doc.s#guide
-
-; Translation API type, currently can only be 1
-; 0: Free version of Youdao API (no longer available, no longer provided by Youdao)
-; 1: Paid version of Youdao API (default value)
-apiType=1
-
-; Parameters for paid version Youdao application
 
 ; Application ID
 appPaidID=xxx
@@ -304,7 +317,7 @@ appPaidKey=xxx
 ; only the paid version of the API can be used. The following parameters related to the free version of the API have been deprecated, please delete them if they are used in your settings file.
 ; apiKey=xxx
 ; keyFrom=xxx
-
+;<<<<<<
 
 ;----------------------------------------------------------------;
 

--- a/language/Simplified_Chinese.ahk
+++ b/language/Simplified_Chinese.ahk
@@ -26,7 +26,12 @@ global lang_yd_errorNoFunds:="帐户余额不足"
 global lang_yd_trans:="------------------------------------有道翻译------------------------------------"
 global lang_yd_dict:="------------------------------------有道词典------------------------------------"
 global lang_yd_phrase:="--------------------------------------短语--------------------------------------"
-global lang_yd_free_key_unavailable_warning:="有道翻译已经不再提供免费的翻译 API，现在只能使用收费 API（新账号有试用额度），请参考 CapsLock+settingsDemo.ini 文件中 [TTranslate] 部分的说明设置密钥后使用翻译功能。"
+global lang_yd_free_key_unavailable_warning:="有道翻译已经不再提供免费的翻译 API，现在只能使用收费 API（新账号有试用额度）或使用openai SDK LLM翻译。请参考 CapsLock+settingsDemo.ini 文件中 [TTranslate] 部分的说明设置密钥后使用翻译功能。"
+
+global lang_openai_name:="LLM翻译"
+global lang_openai_errorConfig:="缺少OpenAI的API配置[Url,Key,Model,Prompt]，LLM翻译无法使用"
+global lang_openai_errorNoNet:="发送请求异常"
+global lang_openai_errorNoResults:="无翻译结果, 可能是网络已断开或文本过长"
 
 global lang_settingsFileContent:=""
 lang_settingsFileContent=
@@ -256,18 +261,29 @@ progressColor=0x00cc99
 ; ## +T翻译设置
 
 [TTranslate]
+;翻译 API 类型，目前只能为 1或2
+;0: 免费版有道 API（已不可使用，有道翻译不再提供）
+;1: 收费版有道 API（默认值）
+;2: 使用兼容OpenAI SDK 的 LLM 翻译（需要配置 OpenAI 的 API， 包含[openaiUrl,openaiKey,openaiModel,openaiPrompt]）
+
+
+apiType=2
+
+;>>>>>>
+;OpenAI API 设置
+openaiUrl=https://api.openai.com/v1/chat/completions
+openaiKey=abc
+openaiModel=gpt-4o
+openaiPrompt="Translate the given text into Chinese. If the text to be translated is a word, please provide a detailed explanation of that word."
+;<<<<<<
+
+;>>>>>>
 ;有道api接口
 ;翻译功能通过调用有道的api实现。
 
 ;收费版api申请网址: https://ai.youdao.com/console/#/
 ;有道翻译 API 入门指南: https://ai.youdao.com/doc.s#guide
-
-;翻译 API 类型，目前只能为 1
-;0: 免费版有道 API（已不可使用，有道翻译不再提供）
-;1: 收费版有道 API（默认值）
-apiType=1
-
-;收费版申请的参数
+;有道翻译收费版申请的参数
 
 ;应用ID
 appPaidID=xxx
@@ -279,6 +295,7 @@ appPaidKey=xxx
 ;只能使用收费版的 API，以下与免费版 API 相关的参数已经废弃，如果你的设置文件中有使用，请删除掉。
 ;apiKey=xxx
 ;keyFrom=xxx
+;<<<<<<
 
 ;----------------------------------------------------------------;
 


### PR DESCRIPTION
新加了有道翻译的apitype=2，可以用LLM来翻译；对应的配置文件做了一些更改
实际上新加的功能放在了原来ydTranslate()的入口，判断apitype=2后跳转。
测试了应该没什么bug
![image](https://github.com/user-attachments/assets/80a05e09-8129-436b-850f-412cc01e7d01)
