### PR TITLE
feat: add settings GUI and pinned window border indicator

### DIFF
--- a/CapsLock+.ahk
+++ b/CapsLock+.ahk
@@ -56,6 +56,7 @@ allowRunOnClipboardChange:=true
 #Include lib_functions.ahk ;public functions
 #Include lib_bindWins.ahk ;capslock+` 1~8, windows bind
 #Include lib_winJump.ahk
+#Include lib_winPinBorder.ahk
 #Include lib_winTransparent.ahk
 #Include lib_mouseSpeed.ahk
 #Include lib_mathBoard.ahk

--- a/CapsLock+.ahk
+++ b/CapsLock+.ahk
@@ -57,6 +57,7 @@ allowRunOnClipboardChange:=true
 #Include lib_bindWins.ahk ;capslock+` 1~8, windows bind
 #Include lib_winJump.ahk
 #Include lib_winPinBorder.ahk
+#Include lib_settingsGui.ahk
 #Include lib_winTransparent.ahk
 #Include lib_mouseSpeed.ahk
 #Include lib_mathBoard.ahk

--- a/language/English.ahk
+++ b/language/English.ahk
@@ -36,6 +36,9 @@ lang_settingsFileContent=
 [Global]
 
 loadScript=scriptDemo.js
+winPinBorderColor=0, 173, 239
+winPinSoundEnabled=1
+winPinSoundFile=
 
 [QSearch]
 
@@ -101,6 +104,15 @@ allowClipboard=1
 
 ; Whether to show the startup loading animation, 1 is yes (default), 0 is no
 loadingAnimation=1
+
+; Border color for pinned windows. Supports RGB (for example 65, 131, 143) or hex (for example #fdfdfd). Default: #00ADEF
+winPinBorderColor=0, 173, 239
+
+; Whether to play a sound when pinning or unpinning, 1 is yes (default), 0 is no
+winPinSoundEnabled=1
+
+; Custom WAV file for pinning sounds. Leave empty to use the PowerToys default sounds
+winPinSoundFile=
 
 ;----------------------------------------------------------------
 ; ## Qbar searching command settings

--- a/language/English.ahk
+++ b/language/English.ahk
@@ -36,9 +36,6 @@ lang_settingsFileContent=
 [Global]
 
 loadScript=scriptDemo.js
-winPinBorderColor=0, 173, 239
-winPinSoundEnabled=1
-winPinSoundFile=
 
 [QSearch]
 

--- a/language/Simplified_Chinese.ahk
+++ b/language/Simplified_Chinese.ahk
@@ -36,6 +36,9 @@ lang_settingsFileContent=
 [Global]
 
 loadScript=scriptDemo.js
+winPinBorderColor=0, 173, 239
+winPinSoundEnabled=1
+winPinSoundFile=
 
 [QSearch]
 
@@ -95,6 +98,15 @@ allowClipboard=1
 
 ;是否开启程序加载动画，1是（默认），0否
 loadingAnimation=1
+
+;顶置窗口外边框颜色。支持 RGB（例如 65, 131, 143）或十六进制（例如 #fdfdfd），默认 #00ADEF
+winPinBorderColor=0, 173, 239
+
+;顶置或取消顶置时是否播放提示音，1为是（默认），0为否
+winPinSoundEnabled=1
+
+;自定义顶置提示音 WAV 文件；留空时使用 PowerToys 同款默认音效
+winPinSoundFile=
 
 ;----------------------------------------------------------------
 ; ## Qbar搜索指令设置

--- a/language/Simplified_Chinese.ahk
+++ b/language/Simplified_Chinese.ahk
@@ -36,9 +36,6 @@ lang_settingsFileContent=
 [Global]
 
 loadScript=scriptDemo.js
-winPinBorderColor=0, 173, 239
-winPinSoundEnabled=1
-winPinSoundFile=
 
 [QSearch]
 

--- a/lib/lib_clQ.ahk
+++ b/lib/lib_clQ.ahk
@@ -376,6 +376,22 @@ progressUpdate(now,total)
 }
 
 
+clqNormalizeColor(value, defaultValue){
+    value:=Trim(value)
+    if(RegExMatch(value, "^\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*$", rgbMatch))
+    {
+        if(rgbMatch1<=255 && rgbMatch2<=255 && rgbMatch3<=255)
+            return Format("{:02X}{:02X}{:02X}", rgbMatch1+0, rgbMatch2+0, rgbMatch3+0)
+        return defaultValue
+    }
+    if(RegExMatch(value, "i)^(?:#|0x)?([0-9a-f]{6})$", hexMatch))
+    {
+        StringUpper, normalizedColor, hexMatch1
+        return normalizedColor
+    }
+    return value!="" ? value : defaultValue
+}
+
 CLq()
 { ;CLq()Start
     global
@@ -465,22 +481,16 @@ CLq()
     guiRadius:=_t!=""?_t:2
     editW:=354
     listW:=editW-2 ;**改代码时注意**：因为edit为了去掉外框而隐藏掉了2px，所以list要和edit对齐就要-2px
-    _t:=CLSets["QStyle"]["borderBackgroundColor"]
-    guiBGColor:=_t!=""?_t:0x555555 ;0x515151 ;0x006ab7 ; 0x002b36 ;窗口背景颜色
-    _t:=CLSets["QStyle"]["textBackgroundColor"]
-    editBGColor:=_t!=""?_t:0xee2255 ;0xff3366 ; 0xd33682 ;edit插件背景颜色
-    _t:=CLSets["QStyle"]["textColor"]
-    editColor:=_t!=""?_t:0xffffff ;edit文字颜色
-    _t:=CLSets["QStyle"]["listColor"]
-    listColor:=_t!=""?_t:0xffffff ;list文字颜色
-    _t:=CLSets["QStyle"]["listBackgroundColor"]
-    listBGColor:=_t!=""?_t:0x333333 ;list背景颜色
-    _t:=CLSets["QStyle"]["progressColor"]
+    guiBGColor:=clqNormalizeColor(CLSets["QStyle"]["borderBackgroundColor"], "555555") ;窗口背景颜色
+    editBGColor:=clqNormalizeColor(CLSets["QStyle"]["textBackgroundColor"], "EE2255") ;edit插件背景颜色
+    editColor:=clqNormalizeColor(CLSets["QStyle"]["textColor"], "FFFFFF") ;edit文字颜色
+    listColor:=clqNormalizeColor(CLSets["QStyle"]["listColor"], "FFFFFF") ;list文字颜色
+    listBGColor:=clqNormalizeColor(CLSets["QStyle"]["listBackgroundColor"], "333333") ;list背景颜色
     editFontName:=CLSets["QStyle"]["textFontName"]
     _t:=CLSets["QStyle"]["textFontSize"]
     editFontSize:=_t!=""?_t:12
     listFontName:=CLSets["QStyle"]["listFontName"]
-    progressColor:=_t!=""?_t:0x11ddaa
+    progressColor:=clqNormalizeColor(CLSets["QStyle"]["progressColor"], "11DDAA")
     editFontSizePx := editFontSize * 4 / 3
     editH := editFontSizePx + 15
     _t:=CLSets["QStyle"]["textHeight"]
@@ -1576,13 +1586,8 @@ ButtonSubmit:
             }
 
             if(paramStr="set"||paramStr="settings")
-            { 
-                IfExist, CapsLock+settingsDemo.ini
-                    Run, CapsLock+settingsDemo.ini
-                
-                IfExist, CapsLock+settings.ini
-                    Run, CapsLock+settings.ini
-                
+            {
+                settingsGui_show()
                 return
             }
             if(paramStr="pay")

--- a/lib/lib_clQ.ahk
+++ b/lib/lib_clQ.ahk
@@ -450,6 +450,8 @@ CLq()
         WinMove, ahk_id %GuiHwnd%, , , , , %h%   ;--cjk1
         ;  WinMove, ahk_id %GuiHwnd%, , , , , %guiH%   ;--cjk1
         WinShow, ahk_id %GuiHwnd%
+        ; 设置面板可能仍处于前台。显示隐藏的 Qbar 后必须主动激活，避免它被设置窗口挡住。
+        WinActivate, ahk_id %GuiHwnd%
         
         WinSetTitle, ahk_id %GuiHwnd%, , Qbar ;上面show出窗口后会把窗口标题改成ahk_id xxxx，改回来
 

--- a/lib/lib_init.ahk
+++ b/lib/lib_init.ahk
@@ -35,6 +35,7 @@ if(isLangChinese())
 ;------------  /language -----------
 
 gosub, settingsInit ;初始化设置
+settingsGui_init()
 
 
 gosub, bindWinsInit

--- a/lib/lib_keysFunction.ahk
+++ b/lib/lib_keysFunction.ahk
@@ -812,9 +812,15 @@ keyFunc_winPin(){
     WinGet, ExStyle, ExStyle, ahk_id %_id%
 
     if(ExStyle & 0x8)
+    {
         winPinBorder_add(_id)
+        winPin_playSound(true)
+    }
     else
+    {
         winPinBorder_remove(_id)
+        winPin_playSound(false)
+    }
     ;  WinSet, Transparent, 210
     return
 }

--- a/lib/lib_keysFunction.ahk
+++ b/lib/lib_keysFunction.ahk
@@ -524,7 +524,15 @@ keyFunc_qbar(){
     ;先关闭所有Caps热键，然后再打开
     ;防止其他功能在 qbar 出来这段时间因为输入文字而被触发
     CapsLock:=CapsLock2:=""
+    needsQbarInit:=needInitQ
     CLq()
+    ; 设置面板或样式变化可能刚重建了 Qbar。第一次调用负责重建，
+    ; 第二次立即显示，避免用户必须再次按 CapsLock+Q。
+    if(needsQbarInit)
+    {
+        DetectHiddenWindows, Off
+        CLq()
+    }
     CapsLock:=1
     return
 

--- a/lib/lib_keysFunction.ahk
+++ b/lib/lib_keysFunction.ahk
@@ -805,15 +805,16 @@ keyFunc_winbind_binding(n){
 
 keyFunc_winPin(){
     _id:=WinExist("A")
-    ;  WinGet, ExStyle, ExStyle
-    ;  if (ExStyle & 0x8)
-    ;  {
-    ;      WinSet, AlwaysOnTop, Off
-    ;      WinSet, Transparent, Off
-    ;
-    ;      return
-    ;  }
-    WinSet, AlwaysOnTop
+    if(!_id)
+        return
+
+    WinSet, AlwaysOnTop, Toggle, ahk_id %_id%
+    WinGet, ExStyle, ExStyle, ahk_id %_id%
+
+    if(ExStyle & 0x8)
+        winPinBorder_add(_id)
+    else
+        winPinBorder_remove(_id)
     ;  WinSet, Transparent, 210
     return
 }

--- a/lib/lib_keysSet.ahk
+++ b/lib/lib_keysSet.ahk
@@ -22,9 +22,9 @@ keysSet_applyQbarExternalApp(){
     global CLSets, keyset
     if(!IsObject(CLSets) || !IsObject(CLSets.Global))
         return
-    if(CLSets.Global.qbarExternalApp="listary")
-        keyset.caps_q:="keyFunc_qbarListary"
-    else if(CLSets.Global.qbarExternalApp="builtin")
+    if(CLSets.Global.qbarExternalApp="external" || CLSets.Global.qbarExternalApp="listary")
+        keyset.caps_q:="keyFunc_qbarExternalApp"
+    else
         keyset.caps_q:="keyFunc_qbar"
 }
 

--- a/lib/lib_keysSet.ahk
+++ b/lib/lib_keysSet.ahk
@@ -13,7 +13,20 @@ if(CLSets.global.default_hotkey_scheme == "capslock_plus") {
     keySchemeInit_capslox()
 }
 
+keysSet_applyQbarExternalApp()
+
 return
+
+
+keysSet_applyQbarExternalApp(){
+    global CLSets, keyset
+    if(!IsObject(CLSets) || !IsObject(CLSets.Global))
+        return
+    if(CLSets.Global.qbarExternalApp="listary")
+        keyset.caps_q:="keyFunc_qbarListary"
+    else if(CLSets.Global.qbarExternalApp="builtin")
+        keyset.caps_q:="keyFunc_qbar"
+}
 
 
 keySchemeInit_capslox(){

--- a/lib/lib_settings.ahk
+++ b/lib/lib_settings.ahk
@@ -96,6 +96,7 @@ if(latestModifyTime!=settingsModifyTime)
     }
     if(isChangeGlobal) ;如果global改过
     {
+        winPinBorder_refreshSettings()
         
         for key1 in setsChanges.Global
         {

--- a/lib/lib_settingsGui.ahk
+++ b/lib/lib_settingsGui.ahk
@@ -1,0 +1,532 @@
+﻿; CapsLock+ 可视化设置面板。先承载窗口顶置设置，后续分类可继续迁入。
+
+global settingsGuiHwnd:=0
+global settingsGuiTrayLabel:=""
+global settingsGuiPage:="general"
+
+settingsGui_init(){
+    global settingsGuiTrayLabel
+
+    settingsGuiTrayLabel:=isLangChinese() ? "设置..." : "Settings..."
+    ; 标准托盘项不能直接用 Menu, Insert 定位。先暂时移除并恢复标准项，
+    ; 将设置放在标准项之前，因此自然位于 Exit 上方且不会破坏系统菜单。
+    Menu, Tray, NoStandard
+    Menu, Tray, Add, %settingsGuiTrayLabel%, settingsGuiOpenFromTray
+    Menu, Tray, Standard
+}
+
+settingsGui_show(){
+    global settingsGuiHwnd, SettingsNavGeneralHighlight, SettingsNavPinHighlight, SettingsNavGeneral, SettingsNavPin
+    global SettingsGeneralTitle, SettingsGeneralDescription, SettingsAutostart, SettingsLoadingAnimation, SettingsAllowClipboard
+    global SettingsMouseSpeedLabel, SettingsMouseSpeed, SettingsSchemeLabel, SettingsHotkeyScheme
+    global SettingsPinTitle, SettingsPinDescription, SettingsPinColorLabel, SettingsPinColorPreview, SettingsPinColorEdit
+    global SettingsPinChooseColor, SettingsPinColorHint, SettingsPinSoundEnabled, SettingsPinSoundFileLabel
+    global SettingsPinSoundFile, SettingsPinChooseSound, SettingsPinSoundDefaultHint
+    global SettingsQbarTitle, SettingsQbarDescription, SettingsQbarExternalApp, SettingsQbarExternalAppLabel, SettingsQbarExternalAppHint
+    global SettingsNavQbarHighlight, SettingsNavQbar, SettingsGuiStatus
+
+    if(settingsGuiHwnd && DllCall("IsWindow", "Ptr", settingsGuiHwnd))
+    {
+        settingsGui_loadValues()
+        Gui, SettingsGui:Show
+        WinActivate, ahk_id %settingsGuiHwnd%
+        return
+    }
+
+    chinese:=isLangChinese()
+    if(chinese)
+    {
+        windowTitle:="CapsLock+ 设置"
+        pinCategory:="窗口顶置"
+        comingSoon:="后续逐步迁移"
+        generalLabel:="常规"
+        hotkeysLabel:="快捷键"
+        translationLabel:="外部程序"
+        qbarLabel:="Qbar"
+        qbarTitle:="Qbar"
+        qbarDescription:="选择 CapsLock+Q 使用内置 Qbar，或绑定外部程序。"
+        qExternalAppLabel:="CapsLock+Q 绑定"
+        qExternalAppItems:="内置 Qbar|Listary"
+        qExternalAppHint:="选择 Listary 后，CapsLock+Q 会呼出 Listary，并自动填入选中文字。"
+        generalTitle:="常规"
+        generalDescription:="管理 CapsLock+ 的启动方式与基础行为。"
+        autostartLabel:="开机时自动启动 CapsLock+"
+        loadingLabel:="启动时显示加载动画"
+        clipboardLabel:="启用独立剪贴板"
+        mouseSpeedLabel:="CapsLock + 左 Alt 临时鼠标速度"
+        schemeLabel:="快捷键布局"
+        schemeItems:="Capslox（推荐）|CapsLock+ 旧版"
+        pageTitle:="窗口顶置"
+        pageDescription:="设置窗口顶置后的视觉边框与操作反馈。"
+        colorLabel:="外边框颜色"
+        colorHint:="支持 RGB（65, 131, 143）或十六进制（#fdfdfd）"
+        chooseLabel:="选择颜色..."
+        soundLabel:="顶置或取消顶置时播放提示音"
+        soundFileLabel:="自定义音效文件"
+        chooseSoundLabel:="选择音效..."
+        soundDefaultHint:="留空时使用 PowerToys 同款的 Speech On / Speech Sleep"
+        resetLabel:="恢复默认"
+        cancelLabel:="取消"
+        saveLabel:="保存"
+        advancedLabel:="打开高级配置文件"
+    }
+    else
+    {
+        windowTitle:="CapsLock+ Settings"
+        pinCategory:="Always on top"
+        comingSoon:="Coming later"
+        generalLabel:="General"
+        hotkeysLabel:="Hotkeys"
+        translationLabel:="External apps"
+        qbarLabel:="Qbar"
+        qbarTitle:="Qbar"
+        qbarDescription:="Use the built-in Qbar or bind CapsLock+Q to an external app."
+        qExternalAppLabel:="CapsLock+Q binding"
+        qExternalAppItems:="Built-in Qbar|Listary"
+        qExternalAppHint:="When Listary is selected, CapsLock+Q opens Listary and fills the selected text."
+        generalTitle:="General"
+        generalDescription:="Manage startup and basic CapsLock+ behavior."
+        autostartLabel:="Start CapsLock+ when Windows starts"
+        loadingLabel:="Show the loading animation at startup"
+        clipboardLabel:="Enable independent clipboards"
+        mouseSpeedLabel:="Temporary mouse speed for CapsLock + Left Alt"
+        schemeLabel:="Hotkey layout"
+        schemeItems:="Capslox (recommended)|Legacy CapsLock+"
+        pageTitle:="Always on top"
+        pageDescription:="Configure the border and feedback for pinned windows."
+        colorLabel:="Border color"
+        colorHint:="RGB (65, 131, 143) or hex (#fdfdfd)"
+        chooseLabel:="Choose color..."
+        soundLabel:="Play a sound when pinning or unpinning"
+        soundFileLabel:="Custom sound file"
+        chooseSoundLabel:="Choose sound..."
+        soundDefaultHint:="Leave empty to use PowerToys Speech On / Speech Sleep"
+        resetLabel:="Reset"
+        cancelLabel:="Cancel"
+        saveLabel:="Save"
+        advancedLabel:="Open advanced config"
+    }
+
+    Gui, SettingsGui:New, +HwndsettingsGuiHwnd -MaximizeBox +MinimizeBox, %windowTitle%
+    Gui, SettingsGui:Margin, 0, 0
+    Gui, SettingsGui:Color, F4F6F8
+
+    ; 左侧分类栏
+    Gui, SettingsGui:Add, Progress, x0 y0 w190 h520 Background20242B c20242B Disabled, 100
+    Gui, SettingsGui:Font, s15 w600 cFFFFFF, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x20 y22 w150 h30 BackgroundTrans, CapsLock+
+    Gui, SettingsGui:Font, s9 w400 c89919D, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x20 y55 w150 h22 BackgroundTrans, %windowTitle%
+    Gui, SettingsGui:Add, Progress, x12 y96 w166 h42 vSettingsNavGeneralHighlight Background1677FF c1677FF Disabled, 100
+    Gui, SettingsGui:Font, s10 w600 cFFFFFF, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x28 y106 w138 h24 vSettingsNavGeneral BackgroundTrans Center gSettingsGuiShowGeneral, %generalLabel%
+    Gui, SettingsGui:Add, Progress, x12 y144 w166 h42 vSettingsNavPinHighlight Background1677FF c1677FF Disabled, 100
+    Gui, SettingsGui:Add, Text, x28 y154 w138 h24 vSettingsNavPin BackgroundTrans Center gSettingsGuiShowPin, %pinCategory%
+    Gui, SettingsGui:Add, Progress, x12 y192 w166 h42 vSettingsNavQbarHighlight Background1677FF c1677FF Disabled, 100
+    Gui, SettingsGui:Add, Text, x28 y202 w138 h24 vSettingsNavQbar BackgroundTrans Center gSettingsGuiShowQbar, %qbarLabel%
+    Gui, SettingsGui:Font, s9 w400 c727B87, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x20 y262 w150 h20 BackgroundTrans, %comingSoon%
+    Gui, SettingsGui:Add, Text, x28 y294 w140 h24 BackgroundTrans, %hotkeysLabel%
+    Gui, SettingsGui:Add, Text, x28 y326 w140 h24 BackgroundTrans, %translationLabel%
+    Gui, SettingsGui:Font, s9 w400 cAAB1BA, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x22 y472 w150 h28 BackgroundTrans gSettingsGuiOpenAdvanced Center 0x200, %advancedLabel%
+
+    ; 右侧内容区
+    Gui, SettingsGui:Add, Progress, x190 y0 w590 h520 BackgroundFFFFFF cFFFFFF Disabled, 100
+    ; 常规设置页
+    Gui, SettingsGui:Font, s18 w600 c20242B, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x226 y28 w510 h36 vSettingsGeneralTitle BackgroundTrans, %generalTitle%
+    Gui, SettingsGui:Font, s9 w400 c68717D, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x228 y70 w500 h24 vSettingsGeneralDescription BackgroundTrans, %generalDescription%
+    Gui, SettingsGui:Font, s10 w400 c252A31, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Checkbox, x228 y126 w420 h26 vSettingsAutostart, %autostartLabel%
+    Gui, SettingsGui:Add, Checkbox, x228 y172 w420 h26 vSettingsLoadingAnimation, %loadingLabel%
+    Gui, SettingsGui:Add, Checkbox, x228 y218 w420 h26 vSettingsAllowClipboard, %clipboardLabel%
+    Gui, SettingsGui:Font, s10 w600 c252A31, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x228 y276 w350 h24 vSettingsMouseSpeedLabel BackgroundTrans, %mouseSpeedLabel%
+    Gui, SettingsGui:Font, s10 w400 c252A31, Microsoft YaHei UI
+    Gui, SettingsGui:Add, DropDownList, x228 y308 w150 vSettingsMouseSpeed, 1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20
+    Gui, SettingsGui:Font, s10 w600 c252A31, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x228 y362 w200 h24 vSettingsSchemeLabel BackgroundTrans, %schemeLabel%
+    Gui, SettingsGui:Font, s10 w400 c252A31, Microsoft YaHei UI
+    Gui, SettingsGui:Add, DropDownList, x228 y394 w260 vSettingsHotkeyScheme AltSubmit, %schemeItems%
+
+    ; 窗口顶置设置页
+    Gui, SettingsGui:Font, s18 w600 c20242B, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x226 y28 w510 h36 vSettingsPinTitle BackgroundTrans, %pageTitle%
+    Gui, SettingsGui:Font, s9 w400 c68717D, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x228 y70 w500 h24 vSettingsPinDescription BackgroundTrans, %pageDescription%
+
+    Gui, SettingsGui:Font, s10 w600 c252A31, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x228 y126 w180 h24 vSettingsPinColorLabel BackgroundTrans, %colorLabel%
+    Gui, SettingsGui:Add, Progress, x228 y158 w44 h36 vSettingsPinColorPreview Background00ADEF c00ADEF Disabled, 100
+    Gui, SettingsGui:Font, s10 w400 c252A31, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Edit, x284 y158 w220 h36 vSettingsPinColorEdit gSettingsGuiColorChanged
+    Gui, SettingsGui:Add, Button, x516 y157 w112 h38 vSettingsPinChooseColor gSettingsGuiChooseColor, %chooseLabel%
+    Gui, SettingsGui:Font, s8 w400 c7B8490, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x284 y200 w350 h20 vSettingsPinColorHint BackgroundTrans, %colorHint%
+
+    Gui, SettingsGui:Font, s10 w400 c252A31, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Checkbox, x228 y258 w380 h26 vSettingsPinSoundEnabled, %soundLabel%
+    Gui, SettingsGui:Font, s10 w600 c252A31, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x228 y304 w240 h24 vSettingsPinSoundFileLabel BackgroundTrans, %soundFileLabel%
+    Gui, SettingsGui:Font, s9 w400 c252A31, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Edit, x228 y336 w380 h36 vSettingsPinSoundFile ReadOnly
+    Gui, SettingsGui:Add, Button, x620 y335 w118 h38 vSettingsPinChooseSound gSettingsGuiChooseSound, %chooseSoundLabel%
+    Gui, SettingsGui:Font, s8 w400 c7B8490, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x228 y378 w500 h20 vSettingsPinSoundDefaultHint BackgroundTrans, %soundDefaultHint%
+
+    ; Qbar 设置页：只保留外部程序绑定，样式继续使用配置文件中的默认值。
+    Gui, SettingsGui:Font, s18 w600 c20242B, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x226 y28 w510 h36 vSettingsQbarTitle BackgroundTrans, %qbarTitle%
+    Gui, SettingsGui:Font, s9 w400 c68717D, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x228 y70 w500 h24 vSettingsQbarDescription BackgroundTrans, %qbarDescription%
+    Gui, SettingsGui:Font, s10 w600 c252A31, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x228 y132 w180 h24 vSettingsQbarExternalAppLabel BackgroundTrans, %qExternalAppLabel%
+    Gui, SettingsGui:Font, s10 w400 c252A31, Microsoft YaHei UI
+    ; r2 让下拉列表一次显示两个选项，避免用户还要滚动才能看到 Listary。
+    Gui, SettingsGui:Add, DropDownList, x228 y166 w280 r2 vSettingsQbarExternalApp AltSubmit, %qExternalAppItems%
+    Gui, SettingsGui:Font, s9 w400 c68717D, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x228 y216 w500 h40 vSettingsQbarExternalAppHint BackgroundTrans, %qExternalAppHint%
+
+    Gui, SettingsGui:Font, s9 w400 c287A46, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x228 y432 w500 h20 vSettingsGuiStatus BackgroundTrans
+    Gui, SettingsGui:Font, s9 w400 c252A31, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Button, x228 y462 w112 h38 gSettingsGuiReset, %resetLabel%
+    Gui, SettingsGui:Add, Button, x522 y462 w96 h38 gSettingsGuiCancel, %cancelLabel%
+    Gui, SettingsGui:Add, Button, x630 y462 w108 h38 gSettingsGuiSave Default, %saveLabel%
+
+    settingsGui_loadValues()
+    settingsGui_setPage("general")
+    Gui, SettingsGui:Show, w780 h520 Center, %windowTitle%
+}
+
+settingsGui_loadValues(){
+    global CLSets, settingsGuiPage
+
+    autostart:=0
+    loadingAnimation:=1
+    allowClipboard:=1
+    mouseSpeed:=3
+    hotkeyScheme:=1
+    colorValue:="0, 173, 239"
+    soundEnabled:=1
+    soundFile:=""
+    qbarExternalApp:=1
+    if(IsObject(CLSets) && IsObject(CLSets.Global))
+    {
+        autostart:=CLSets.Global.autostart ? 1 : 0
+        if(CLSets.Global.loadingAnimation="0")
+            loadingAnimation:=0
+        if(CLSets.Global.allowClipboard="0")
+            allowClipboard:=0
+        if(CLSets.Global.mouseSpeed>=1 && CLSets.Global.mouseSpeed<=20)
+            mouseSpeed:=CLSets.Global.mouseSpeed
+        if(CLSets.Global.default_hotkey_scheme="capslock_plus")
+            hotkeyScheme:=2
+        if(CLSets.Global.winPinBorderColor!="")
+            colorValue:=CLSets.Global.winPinBorderColor
+        if(CLSets.Global.winPinSoundEnabled="0")
+            soundEnabled:=0
+        if(CLSets.Global.winPinSoundFile!="")
+            soundFile:=CLSets.Global.winPinSoundFile
+        if(CLSets.Global.qbarExternalApp="listary")
+            qbarExternalApp:=2
+    }
+    if(qbarExternalApp=1 && IsObject(CLSets) && IsObject(CLSets.Keys)
+        && InStr(CLSets.Keys.caps_q, "listary"))
+        qbarExternalApp:=2
+    ; 旧版 Qbar 页面曾把示例红/绿/蓝配色写入配置。内置模式下自动迁移回原始默认值。
+    if(qbarExternalApp=1 && IsObject(CLSets) && IsObject(CLSets.QStyle)
+        && CLSets.QStyle.borderBackgroundColor="red"
+        && CLSets.QStyle.textBackgroundColor="green"
+        && CLSets.QStyle.listBackgroundColor="blue")
+        settingsGui_restoreQbarDefaults()
+    GuiControl, SettingsGui:, SettingsAutostart, %autostart%
+    GuiControl, SettingsGui:, SettingsLoadingAnimation, %loadingAnimation%
+    GuiControl, SettingsGui:, SettingsAllowClipboard, %allowClipboard%
+    GuiControl, SettingsGui:Choose, SettingsMouseSpeed, %mouseSpeed%
+    GuiControl, SettingsGui:Choose, SettingsHotkeyScheme, %hotkeyScheme%
+    GuiControl, SettingsGui:, SettingsPinColorEdit, %colorValue%
+    GuiControl, SettingsGui:, SettingsPinSoundEnabled, %soundEnabled%
+    GuiControl, SettingsGui:, SettingsPinSoundFile, %soundFile%
+    GuiControl, SettingsGui:Choose, SettingsQbarExternalApp, %qbarExternalApp%
+    settingsGui_updateColorPreview(colorValue)
+    GuiControl, SettingsGui:, SettingsGuiStatus,
+}
+
+settingsGui_setPage(page){
+    global settingsGuiPage
+
+    generalControls:="SettingsGeneralTitle|SettingsGeneralDescription|SettingsAutostart|SettingsLoadingAnimation|SettingsAllowClipboard|SettingsMouseSpeedLabel|SettingsMouseSpeed|SettingsSchemeLabel|SettingsHotkeyScheme"
+    pinControls:="SettingsPinTitle|SettingsPinDescription|SettingsPinColorLabel|SettingsPinColorPreview|SettingsPinColorEdit|SettingsPinChooseColor|SettingsPinColorHint|SettingsPinSoundEnabled|SettingsPinSoundFileLabel|SettingsPinSoundFile|SettingsPinChooseSound|SettingsPinSoundDefaultHint"
+    qbarControls:="SettingsQbarTitle|SettingsQbarDescription|SettingsQbarExternalAppLabel|SettingsQbarExternalApp|SettingsQbarExternalAppHint"
+    if(page="pin")
+    {
+        settingsGuiPage:="pin"
+        for index,controlName in StrSplit(generalControls, "|")
+            GuiControl, SettingsGui:Hide, %controlName%
+        for index,controlName in StrSplit(qbarControls, "|")
+            GuiControl, SettingsGui:Hide, %controlName%
+        for index,controlName in StrSplit(pinControls, "|")
+            GuiControl, SettingsGui:Show, %controlName%
+        GuiControl, SettingsGui:Hide, SettingsNavGeneralHighlight
+        GuiControl, SettingsGui:Hide, SettingsNavQbarHighlight
+        GuiControl, SettingsGui:Show, SettingsNavPinHighlight
+        GuiControl, SettingsGui:+c89919D, SettingsNavGeneral
+        GuiControl, SettingsGui:+cFFFFFF, SettingsNavPin
+        GuiControl, SettingsGui:+c89919D, SettingsNavQbar
+    }
+    else if(page="qbar")
+    {
+        settingsGuiPage:="qbar"
+        for index,controlName in StrSplit(generalControls, "|")
+            GuiControl, SettingsGui:Hide, %controlName%
+        for index,controlName in StrSplit(pinControls, "|")
+            GuiControl, SettingsGui:Hide, %controlName%
+        for index,controlName in StrSplit(qbarControls, "|")
+            GuiControl, SettingsGui:Show, %controlName%
+        GuiControl, SettingsGui:Hide, SettingsNavGeneralHighlight
+        GuiControl, SettingsGui:Hide, SettingsNavPinHighlight
+        GuiControl, SettingsGui:Show, SettingsNavQbarHighlight
+        GuiControl, SettingsGui:+c89919D, SettingsNavGeneral
+        GuiControl, SettingsGui:+c89919D, SettingsNavPin
+        GuiControl, SettingsGui:+cFFFFFF, SettingsNavQbar
+    }
+    else
+    {
+        settingsGuiPage:="general"
+        for index,controlName in StrSplit(pinControls, "|")
+            GuiControl, SettingsGui:Hide, %controlName%
+        for index,controlName in StrSplit(qbarControls, "|")
+            GuiControl, SettingsGui:Hide, %controlName%
+        for index,controlName in StrSplit(generalControls, "|")
+            GuiControl, SettingsGui:Show, %controlName%
+        GuiControl, SettingsGui:Hide, SettingsNavPinHighlight
+        GuiControl, SettingsGui:Hide, SettingsNavQbarHighlight
+        GuiControl, SettingsGui:Show, SettingsNavGeneralHighlight
+        GuiControl, SettingsGui:+cFFFFFF, SettingsNavGeneral
+        GuiControl, SettingsGui:+c89919D, SettingsNavPin
+        GuiControl, SettingsGui:+c89919D, SettingsNavQbar
+    }
+    GuiControl, SettingsGui:, SettingsGuiStatus,
+}
+
+settingsGui_updateColorPreview(colorValue){
+    if(!winPinBorder_tryParseColor(colorValue, normalizedColor))
+        normalizedColor:="D9DEE5"
+    GuiControl, SettingsGui:+c%normalizedColor%, SettingsPinColorPreview
+    GuiControl, SettingsGui:, SettingsPinColorPreview, 100
+}
+
+settingsGui_save(){
+    global CLSets, settingsGuiPage, SettingsAutostart, SettingsLoadingAnimation, SettingsAllowClipboard, SettingsMouseSpeed, SettingsHotkeyScheme
+    global SettingsPinColorEdit, SettingsPinSoundEnabled, SettingsPinSoundFile
+    global SettingsQbarExternalApp
+    global needInitQ
+
+    Gui, SettingsGui:Submit, NoHide
+    colorValue:=Trim(SettingsPinColorEdit)
+    if(!winPinBorder_tryParseColor(colorValue, normalizedColor))
+    {
+        message:=isLangChinese() ? "颜色格式无效。请输入 65, 131, 143 或 #fdfdfd。" : "Invalid color. Use 65, 131, 143 or #fdfdfd."
+        MsgBox, 0x40030, CapsLock+, %message%
+        return false
+    }
+
+    soundEnabled:=SettingsPinSoundEnabled ? 1 : 0
+    soundFile:=Trim(SettingsPinSoundFile)
+    if(soundFile!="" && !FileExist(soundFile))
+    {
+        message:=isLangChinese() ? "选择的音效文件不存在，请重新选择或恢复默认。" : "The selected sound file does not exist. Choose another file or reset it."
+        MsgBox, 0x40030, CapsLock+, %message%
+        return false
+    }
+
+    qbarExternalApp:=SettingsQbarExternalApp=2 ? "listary" : "builtin"
+    qbarKeyValue:=qbarExternalApp="listary" ? "keyFunc_qbarListary" : "keyFunc_qbar"
+
+    ; 内置 Qbar 不再暴露样式选项，切回内置模式时恢复项目原始样式。
+    if(settingsGuiPage="qbar" && qbarExternalApp="builtin")
+        settingsGui_restoreQbarDefaults()
+
+    autostart:=SettingsAutostart ? 1 : 0
+    loadingAnimation:=SettingsLoadingAnimation ? 1 : 0
+    allowClipboard:=SettingsAllowClipboard ? 1 : 0
+    mouseSpeed:=SettingsMouseSpeed
+    hotkeyScheme:=SettingsHotkeyScheme=2 ? "capslock_plus" : "capslox"
+
+    IniWrite, %autostart%, CapsLock+settings.ini, Global, autostart
+    IniWrite, %loadingAnimation%, CapsLock+settings.ini, Global, loadingAnimation
+    IniWrite, %allowClipboard%, CapsLock+settings.ini, Global, allowClipboard
+    IniWrite, %mouseSpeed%, CapsLock+settings.ini, Global, mouseSpeed
+    IniWrite, %hotkeyScheme%, CapsLock+settings.ini, Global, default_hotkey_scheme
+    IniWrite, %colorValue%, CapsLock+settings.ini, Global, winPinBorderColor
+    IniWrite, %soundEnabled%, CapsLock+settings.ini, Global, winPinSoundEnabled
+    IniWrite, %soundFile%, CapsLock+settings.ini, Global, winPinSoundFile
+    IniWrite, %qbarExternalApp%, CapsLock+settings.ini, Global, qbarExternalApp
+    IniWrite, %qbarKeyValue%, CapsLock+settings.ini, Keys, caps_q
+
+    if(!IsObject(CLSets.Global))
+        CLSets.Global:={}
+    CLSets.Global.autostart:=autostart
+    CLSets.Global.loadingAnimation:=loadingAnimation
+    CLSets.Global.allowClipboard:=allowClipboard
+    CLSets.Global.mouseSpeed:=mouseSpeed
+    CLSets.Global.default_hotkey_scheme:=hotkeyScheme
+    CLSets.Global.winPinBorderColor:=colorValue
+    CLSets.Global.winPinSoundEnabled:=soundEnabled
+    CLSets.Global.winPinSoundFile:=soundFile
+    CLSets.Global.qbarExternalApp:=qbarExternalApp
+    if(!IsObject(CLSets.Keys))
+        CLSets.Keys:={}
+    CLSets.Keys.caps_q:=qbarKeyValue
+    needInitQ:=1
+    winPinBorder_refreshSettings()
+    settingsGui_updateColorPreview(colorValue)
+    if(IsLabel("globalSettings"))
+    {
+        settingsTimerLabel:="globalSettings"
+        SetTimer, %settingsTimerLabel%, -1
+    }
+    if(IsLabel("keysInit"))
+    {
+        settingsTimerLabel:="keysInit"
+        SetTimer, %settingsTimerLabel%, -1
+    }
+    if(IsLabel("mouseSpeedInit"))
+    {
+        settingsTimerLabel:="mouseSpeedInit"
+        SetTimer, %settingsTimerLabel%, -1
+    }
+
+    if(settingsGuiPage="qbar")
+        savedText:=isLangChinese() ? "设置已保存，Qbar 下次打开时应用。" : "Saved. Qbar will apply it next time it opens."
+    else
+        savedText:=isLangChinese() ? "设置已保存并立即生效。" : "Settings saved and applied."
+    GuiControl, SettingsGui:, SettingsGuiStatus, %savedText%
+    return true
+}
+
+settingsGui_restoreQbarDefaults(){
+    global CLSets, needInitQ
+    ; 这些值来自 lib_clQ 原有的内置回退值，而不是设置示例里的红/绿/蓝配色。
+    defaults:={borderBackgroundColor:"555555", borderRadius:2, textBackgroundColor:"EE2255", textColor:"FFFFFF"
+        , textFontName:"", textFontSize:12, listFontName:"", listFontSize:10
+        , listBackgroundColor:"333333", listColor:"FFFFFF", listCount:10, lineHeight:19, progressColor:"11DDAA"}
+    for key,value in defaults
+        IniWrite, %value%, CapsLock+settings.ini, QStyle, %key%
+    if(!IsObject(CLSets.QStyle))
+        CLSets.QStyle:={}
+    for key,value in defaults
+        CLSets.QStyle[key]:=value
+    needInitQ:=1
+}
+
+settingsGui_chooseColor(ownerHwnd, initialColor){
+    static customColors
+    VarSetCapacity(customColors, 64, 0)
+    if(!winPinBorder_tryParseColor(initialColor, normalizedColor))
+        normalizedColor:="00ADEF"
+
+    red:=("0x" . SubStr(normalizedColor, 1, 2))+0
+    green:=("0x" . SubStr(normalizedColor, 3, 2))+0
+    blue:=("0x" . SubStr(normalizedColor, 5, 2))+0
+    colorRef:=red | (green << 8) | (blue << 16)
+
+    structSize:=A_PtrSize=8 ? 72 : 36
+    ownerOffset:=A_PtrSize=8 ? 8 : 4
+    resultOffset:=A_PtrSize=8 ? 24 : 12
+    customOffset:=A_PtrSize=8 ? 32 : 16
+    flagsOffset:=A_PtrSize=8 ? 40 : 20
+    VarSetCapacity(chooseColor, structSize, 0)
+    NumPut(structSize, chooseColor, 0, "UInt")
+    NumPut(ownerHwnd, chooseColor, ownerOffset, "Ptr")
+    NumPut(colorRef, chooseColor, resultOffset, "UInt")
+    NumPut(&customColors, chooseColor, customOffset, "Ptr")
+    NumPut(0x103, chooseColor, flagsOffset, "UInt") ; CC_RGBINIT | CC_FULLOPEN
+
+    if(!DllCall("Comdlg32\ChooseColorW", "Ptr", &chooseColor))
+        return ""
+    selected:=NumGet(chooseColor, resultOffset, "UInt")
+    return (selected & 0xFF) . ", " . ((selected >> 8) & 0xFF) . ", " . ((selected >> 16) & 0xFF)
+}
+
+settingsGuiOpenFromTray:
+settingsGui_show()
+return
+
+SettingsGuiColorChanged:
+GuiControlGet, changedColor, SettingsGui:, SettingsPinColorEdit
+settingsGui_updateColorPreview(changedColor)
+return
+
+SettingsGuiChooseColor:
+GuiControlGet, currentColor, SettingsGui:, SettingsPinColorEdit
+selectedColor:=settingsGui_chooseColor(settingsGuiHwnd, currentColor)
+if(selectedColor!="")
+{
+    GuiControl, SettingsGui:, SettingsPinColorEdit, %selectedColor%
+    settingsGui_updateColorPreview(selectedColor)
+}
+return
+
+SettingsGuiShowGeneral:
+settingsGui_setPage("general")
+return
+
+SettingsGuiShowPin:
+settingsGui_setPage("pin")
+return
+
+SettingsGuiShowQbar:
+settingsGui_setPage("qbar")
+return
+
+SettingsGuiChooseSound:
+GuiControlGet, currentSoundFile, SettingsGui:, SettingsPinSoundFile
+soundStartDirectory:=A_WinDir . "\Media"
+if(currentSoundFile!="" && FileExist(currentSoundFile))
+    SplitPath, currentSoundFile, , soundStartDirectory
+soundDialogTitle:=isLangChinese() ? "选择顶置提示音" : "Choose pinning sound"
+FileSelectFile, selectedSoundFile, 1, %soundStartDirectory%, %soundDialogTitle%, WAV Audio (*.wav)
+if(selectedSoundFile!="")
+    GuiControl, SettingsGui:, SettingsPinSoundFile, %selectedSoundFile%
+return
+
+SettingsGuiReset:
+if(settingsGuiPage="pin")
+{
+    GuiControl, SettingsGui:, SettingsPinColorEdit, 0`, 173`, 239
+    GuiControl, SettingsGui:, SettingsPinSoundEnabled, 1
+    GuiControl, SettingsGui:, SettingsPinSoundFile,
+    settingsGui_updateColorPreview("0, 173, 239")
+}
+else if(settingsGuiPage="qbar")
+{
+    GuiControl, SettingsGui:Choose, SettingsQbarExternalApp, 1
+}
+else
+{
+    GuiControl, SettingsGui:, SettingsAutostart, 0
+    GuiControl, SettingsGui:, SettingsLoadingAnimation, 1
+    GuiControl, SettingsGui:, SettingsAllowClipboard, 1
+    GuiControl, SettingsGui:Choose, SettingsMouseSpeed, 3
+    GuiControl, SettingsGui:Choose, SettingsHotkeyScheme, 1
+}
+GuiControl, SettingsGui:, SettingsGuiStatus,
+return
+
+SettingsGuiSave:
+settingsGui_save()
+return
+
+SettingsGuiOpenAdvanced:
+Run, CapsLock+settings.ini
+return
+
+SettingsGuiCancel:
+SettingsGuiClose:
+SettingsGuiEscape:
+Gui, SettingsGui:Hide
+return

--- a/lib/lib_settingsGui.ahk
+++ b/lib/lib_settingsGui.ahk
@@ -3,6 +3,7 @@
 global settingsGuiHwnd:=0
 global settingsGuiTrayLabel:=""
 global settingsGuiPage:="general"
+global settingsGuiPhrases:=[]
 
 settingsGui_init(){
     global settingsGuiTrayLabel
@@ -13,17 +14,23 @@ settingsGui_init(){
     Menu, Tray, NoStandard
     Menu, Tray, Add, %settingsGuiTrayLabel%, settingsGuiOpenFromTray
     Menu, Tray, Standard
+    settingsGui_cleanupConfigDefaults()
 }
 
 settingsGui_show(){
-    global settingsGuiHwnd, SettingsNavGeneralHighlight, SettingsNavPinHighlight, SettingsNavGeneral, SettingsNavPin
+    global settingsGuiHwnd, SettingsNavGeneralHighlight, SettingsNavPinHighlight, SettingsNavQbarHighlight, SettingsNavHotkeysHighlight, SettingsNavPhrasesHighlight
+    global SettingsNavGeneral, SettingsNavPin, SettingsNavQbar, SettingsNavHotkeys, SettingsNavPhrases
     global SettingsGeneralTitle, SettingsGeneralDescription, SettingsAutostart, SettingsLoadingAnimation, SettingsAllowClipboard
     global SettingsMouseSpeedLabel, SettingsMouseSpeed, SettingsSchemeLabel, SettingsHotkeyScheme
+    global SettingsHotkeysTitle, SettingsHotkeysDescription, SettingsHotkeysHint
     global SettingsPinTitle, SettingsPinDescription, SettingsPinColorLabel, SettingsPinColorPreview, SettingsPinColorEdit
     global SettingsPinChooseColor, SettingsPinColorHint, SettingsPinSoundEnabled, SettingsPinSoundFileLabel
     global SettingsPinSoundFile, SettingsPinChooseSound, SettingsPinSoundDefaultHint
     global SettingsQbarTitle, SettingsQbarDescription, SettingsQbarExternalApp, SettingsQbarExternalAppLabel, SettingsQbarExternalAppHint
-    global SettingsNavQbarHighlight, SettingsNavQbar, SettingsGuiStatus
+    global SettingsQbarExternalPath, SettingsQbarExternalPathLabel, SettingsQbarExternalPathHint, SettingsQbarChooseExternalPath
+    global SettingsPhrasesTitle, SettingsPhrasesDescription, SettingsPhraseListView, SettingsPhraseTriggerLabel, SettingsPhraseReplacementLabel
+    global SettingsPhraseTrigger, SettingsPhraseReplacement, SettingsPhraseAddButton, SettingsPhraseDeleteButton
+    global SettingsGuiStatus
 
     if(settingsGuiHwnd && DllCall("IsWindow", "Ptr", settingsGuiHwnd))
     {
@@ -38,16 +45,27 @@ settingsGui_show(){
     {
         windowTitle:="CapsLock+ 设置"
         pinCategory:="窗口顶置"
-        comingSoon:="后续逐步迁移"
         generalLabel:="常规"
         hotkeysLabel:="快捷键"
-        translationLabel:="外部程序"
+        hotkeysTitle:="快捷键"
+        hotkeysDescription:="选择 CapsLock+ 的快捷键布局。"
+        hotkeysHint:="Capslox 为新版布局；CapsLock+ 旧版适合习惯旧快捷键的用户。"
+        phrasesLabel:="常用语"
+        phrasesTitle:="常用语"
+        phrasesDescription:="设置 CapsLock+Tab 的文字替换短语；选中条目后直接编辑，点击底部“保存”。"
+        phrasesTriggerLabel:="触发词"
+        phrasesReplacementLabel:="替换内容"
+        phrasesAddLabel:="添加"
+        phrasesDeleteLabel:="删除"
         qbarLabel:="Qbar"
         qbarTitle:="Qbar"
         qbarDescription:="选择 CapsLock+Q 使用内置 Qbar，或绑定外部程序。"
         qExternalAppLabel:="CapsLock+Q 绑定"
-        qExternalAppItems:="内置 Qbar|Listary"
-        qExternalAppHint:="选择 Listary 后，CapsLock+Q 会呼出 Listary，并自动填入选中文字。"
+        qExternalAppItems:="内置 Qbar|外部程序"
+        qExternalAppHint:="选择外部程序后，CapsLock+Q 会启动或激活该程序。"
+        qExternalPathLabel:="外部程序路径"
+        qExternalChoosePathLabel:="选择程序..."
+        qExternalPathHint:="选择外部程序后必须填写有效路径，保存时会检查文件是否存在。"
         generalTitle:="常规"
         generalDescription:="管理 CapsLock+ 的启动方式与基础行为。"
         autostartLabel:="开机时自动启动 CapsLock+"
@@ -74,16 +92,27 @@ settingsGui_show(){
     {
         windowTitle:="CapsLock+ Settings"
         pinCategory:="Always on top"
-        comingSoon:="Coming later"
         generalLabel:="General"
         hotkeysLabel:="Hotkeys"
-        translationLabel:="External apps"
+        hotkeysTitle:="Hotkeys"
+        hotkeysDescription:="Choose the CapsLock+ keyboard layout."
+        hotkeysHint:="Capslox is the current layout; Legacy keeps the older shortcut arrangement."
+        phrasesLabel:="Phrases"
+        phrasesTitle:="Phrases"
+        phrasesDescription:="Manage CapsLock+Tab phrases; edit a selected row and click Save below."
+        phrasesTriggerLabel:="Trigger"
+        phrasesReplacementLabel:="Replacement"
+        phrasesAddLabel:="Add"
+        phrasesDeleteLabel:="Delete"
         qbarLabel:="Qbar"
         qbarTitle:="Qbar"
         qbarDescription:="Use the built-in Qbar or bind CapsLock+Q to an external app."
         qExternalAppLabel:="CapsLock+Q binding"
-        qExternalAppItems:="Built-in Qbar|Listary"
-        qExternalAppHint:="When Listary is selected, CapsLock+Q opens Listary and fills the selected text."
+        qExternalAppItems:="Built-in Qbar|External app"
+        qExternalAppHint:="When an external app is selected, CapsLock+Q starts or activates it."
+        qExternalPathLabel:="External app path"
+        qExternalChoosePathLabel:="Browse..."
+        qExternalPathHint:="An existing path is required when an external app is selected."
         generalTitle:="General"
         generalDescription:="Manage startup and basic CapsLock+ behavior."
         autostartLabel:="Start CapsLock+ when Windows starts"
@@ -124,10 +153,10 @@ settingsGui_show(){
     Gui, SettingsGui:Add, Text, x28 y154 w138 h24 vSettingsNavPin BackgroundTrans Center gSettingsGuiShowPin, %pinCategory%
     Gui, SettingsGui:Add, Progress, x12 y192 w166 h42 vSettingsNavQbarHighlight Background1677FF c1677FF Disabled, 100
     Gui, SettingsGui:Add, Text, x28 y202 w138 h24 vSettingsNavQbar BackgroundTrans Center gSettingsGuiShowQbar, %qbarLabel%
-    Gui, SettingsGui:Font, s9 w400 c727B87, Microsoft YaHei UI
-    Gui, SettingsGui:Add, Text, x20 y262 w150 h20 BackgroundTrans, %comingSoon%
-    Gui, SettingsGui:Add, Text, x28 y294 w140 h24 BackgroundTrans, %hotkeysLabel%
-    Gui, SettingsGui:Add, Text, x28 y326 w140 h24 BackgroundTrans, %translationLabel%
+    Gui, SettingsGui:Add, Progress, x12 y246 w166 h42 vSettingsNavHotkeysHighlight Background1677FF c1677FF Disabled, 100
+    Gui, SettingsGui:Add, Text, x28 y256 w138 h24 vSettingsNavHotkeys BackgroundTrans Center gSettingsGuiShowHotkeys, %hotkeysLabel%
+    Gui, SettingsGui:Add, Progress, x12 y300 w166 h42 vSettingsNavPhrasesHighlight Background1677FF c1677FF Disabled, 100
+    Gui, SettingsGui:Add, Text, x28 y310 w138 h24 vSettingsNavPhrases BackgroundTrans Center gSettingsGuiShowPhrases, %phrasesLabel%
     Gui, SettingsGui:Font, s9 w400 cAAB1BA, Microsoft YaHei UI
     Gui, SettingsGui:Add, Text, x22 y472 w150 h28 BackgroundTrans gSettingsGuiOpenAdvanced Center 0x200, %advancedLabel%
 
@@ -146,10 +175,17 @@ settingsGui_show(){
     Gui, SettingsGui:Add, Text, x228 y276 w350 h24 vSettingsMouseSpeedLabel BackgroundTrans, %mouseSpeedLabel%
     Gui, SettingsGui:Font, s10 w400 c252A31, Microsoft YaHei UI
     Gui, SettingsGui:Add, DropDownList, x228 y308 w150 vSettingsMouseSpeed, 1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20
+    ; 快捷键设置页
+    Gui, SettingsGui:Font, s18 w600 c20242B, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x226 y28 w510 h36 vSettingsHotkeysTitle BackgroundTrans, %hotkeysTitle%
+    Gui, SettingsGui:Font, s9 w400 c68717D, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x228 y70 w500 h24 vSettingsHotkeysDescription BackgroundTrans, %hotkeysDescription%
     Gui, SettingsGui:Font, s10 w600 c252A31, Microsoft YaHei UI
-    Gui, SettingsGui:Add, Text, x228 y362 w200 h24 vSettingsSchemeLabel BackgroundTrans, %schemeLabel%
+    Gui, SettingsGui:Add, Text, x228 y132 w240 h24 vSettingsSchemeLabel BackgroundTrans, %schemeLabel%
     Gui, SettingsGui:Font, s10 w400 c252A31, Microsoft YaHei UI
-    Gui, SettingsGui:Add, DropDownList, x228 y394 w260 vSettingsHotkeyScheme AltSubmit, %schemeItems%
+    Gui, SettingsGui:Add, DropDownList, x228 y166 w300 r2 vSettingsHotkeyScheme AltSubmit, %schemeItems%
+    Gui, SettingsGui:Font, s9 w400 c68717D, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x228 y216 w500 h40 vSettingsHotkeysHint BackgroundTrans, %hotkeysHint%
 
     ; 窗口顶置设置页
     Gui, SettingsGui:Font, s18 w600 c20242B, Microsoft YaHei UI
@@ -184,11 +220,34 @@ settingsGui_show(){
     Gui, SettingsGui:Font, s10 w600 c252A31, Microsoft YaHei UI
     Gui, SettingsGui:Add, Text, x228 y132 w180 h24 vSettingsQbarExternalAppLabel BackgroundTrans, %qExternalAppLabel%
     Gui, SettingsGui:Font, s10 w400 c252A31, Microsoft YaHei UI
-    ; r2 让下拉列表一次显示两个选项，避免用户还要滚动才能看到 Listary。
-    Gui, SettingsGui:Add, DropDownList, x228 y166 w280 r2 vSettingsQbarExternalApp AltSubmit, %qExternalAppItems%
+    ; r2 让下拉列表一次显示两个选项。
+    Gui, SettingsGui:Add, DropDownList, x228 y166 w280 r2 vSettingsQbarExternalApp gSettingsGuiQbarExternalChanged AltSubmit, %qExternalAppItems%
     Gui, SettingsGui:Font, s9 w400 c68717D, Microsoft YaHei UI
     Gui, SettingsGui:Add, Text, x228 y216 w500 h40 vSettingsQbarExternalAppHint BackgroundTrans, %qExternalAppHint%
+    Gui, SettingsGui:Font, s10 w600 c252A31, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x228 y276 w240 h24 vSettingsQbarExternalPathLabel BackgroundTrans, %qExternalPathLabel%
+    Gui, SettingsGui:Font, s9 w400 c252A31, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Edit, x228 y310 w380 h32 vSettingsQbarExternalPath
+    Gui, SettingsGui:Add, Button, x620 y309 w118 h34 vSettingsQbarChooseExternalPath gSettingsGuiChooseExternalPath, %qExternalChoosePathLabel%
+    Gui, SettingsGui:Font, s8 w400 c68717D, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x228 y350 w500 h32 vSettingsQbarExternalPathHint BackgroundTrans, %qExternalPathHint%
 
+    ; 常用语设置页
+    phraseColumns:=phrasesTriggerLabel . "|" . phrasesReplacementLabel
+    Gui, SettingsGui:Font, s18 w600 c20242B, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x226 y28 w510 h36 vSettingsPhrasesTitle BackgroundTrans, %phrasesTitle%
+    Gui, SettingsGui:Font, s9 w400 c68717D, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x228 y70 w500 h24 vSettingsPhrasesDescription BackgroundTrans, %phrasesDescription%
+    Gui, SettingsGui:Font, s9 w400 c252A31, Microsoft YaHei UI
+    Gui, SettingsGui:Add, ListView, x228 y112 w510 h190 vSettingsPhraseListView gSettingsGuiPhraseListChanged Grid AltSubmit, %phraseColumns%
+    Gui, SettingsGui:Font, s9 w600 c252A31, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Text, x228 y318 w245 h22 vSettingsPhraseTriggerLabel BackgroundTrans, %phrasesTriggerLabel%
+    Gui, SettingsGui:Add, Text, x493 y318 w245 h22 vSettingsPhraseReplacementLabel BackgroundTrans, %phrasesReplacementLabel%
+    Gui, SettingsGui:Font, s9 w400 c252A31, Microsoft YaHei UI
+    Gui, SettingsGui:Add, Edit, x228 y342 w245 h48 vSettingsPhraseTrigger
+    Gui, SettingsGui:Add, Edit, x493 y342 w245 h48 r3 vSettingsPhraseReplacement
+    Gui, SettingsGui:Add, Button, x228 y400 w96 h32 vSettingsPhraseAddButton gSettingsGuiPhraseAdd, %phrasesAddLabel%
+    Gui, SettingsGui:Add, Button, x334 y400 w96 h32 vSettingsPhraseDeleteButton gSettingsGuiPhraseDelete, %phrasesDeleteLabel%
     Gui, SettingsGui:Font, s9 w400 c287A46, Microsoft YaHei UI
     Gui, SettingsGui:Add, Text, x228 y432 w500 h20 vSettingsGuiStatus BackgroundTrans
     Gui, SettingsGui:Font, s9 w400 c252A31, Microsoft YaHei UI
@@ -213,6 +272,7 @@ settingsGui_loadValues(){
     soundEnabled:=1
     soundFile:=""
     qbarExternalApp:=1
+    externalPath:=""
     if(IsObject(CLSets) && IsObject(CLSets.Global))
     {
         autostart:=CLSets.Global.autostart ? 1 : 0
@@ -230,17 +290,28 @@ settingsGui_loadValues(){
             soundEnabled:=0
         if(CLSets.Global.winPinSoundFile!="")
             soundFile:=CLSets.Global.winPinSoundFile
-        if(CLSets.Global.qbarExternalApp="listary")
+        if(CLSets.Global.qbarExternalApp="external" || CLSets.Global.qbarExternalApp="listary")
             qbarExternalApp:=2
+        if(CLSets.Global.externalAppPath!="")
+            externalPath:=CLSets.Global.externalAppPath
+        else if(CLSets.Global.listaryPath!="")
+            externalPath:=CLSets.Global.listaryPath
     }
     if(qbarExternalApp=1 && IsObject(CLSets) && IsObject(CLSets.Keys)
-        && InStr(CLSets.Keys.caps_q, "listary"))
+        && (InStr(CLSets.Keys.caps_q, "qbarExternalApp") || InStr(CLSets.Keys.caps_q, "qbarListary") || InStr(CLSets.Keys.caps_q, "listary")))
         qbarExternalApp:=2
-    ; 旧版 Qbar 页面曾把示例红/绿/蓝配色写入配置。内置模式下自动迁移回原始默认值。
-    if(qbarExternalApp=1 && IsObject(CLSets) && IsObject(CLSets.QStyle)
-        && CLSets.QStyle.borderBackgroundColor="red"
-        && CLSets.QStyle.textBackgroundColor="green"
-        && CLSets.QStyle.listBackgroundColor="blue")
+    ; Qbar 样式不再由设置面板管理。只有检测到旧样式键时才重建 Qbar，
+    ; 避免每次打开设置面板都把已初始化的 Qbar 标记为需要重建。
+    styleHasValues:=false
+    if(IsObject(CLSets) && IsObject(CLSets.QStyle))
+    {
+        for key,value in CLSets.QStyle
+        {
+            styleHasValues:=true
+            break
+        }
+    }
+    if(styleHasValues)
         settingsGui_restoreQbarDefaults()
     GuiControl, SettingsGui:, SettingsAutostart, %autostart%
     GuiControl, SettingsGui:, SettingsLoadingAnimation, %loadingAnimation%
@@ -251,65 +322,400 @@ settingsGui_loadValues(){
     GuiControl, SettingsGui:, SettingsPinSoundEnabled, %soundEnabled%
     GuiControl, SettingsGui:, SettingsPinSoundFile, %soundFile%
     GuiControl, SettingsGui:Choose, SettingsQbarExternalApp, %qbarExternalApp%
+    GuiControl, SettingsGui:, SettingsQbarExternalPath, %externalPath%
+    settingsGui_updateQbarExternalControls(qbarExternalApp=2)
+    ; 打开或重新打开设置页时，先恢复已保存的 Qbar 路由，避免取消编辑留下临时预览状态。
+    keysSet_applyQbarExternalApp()
     settingsGui_updateColorPreview(colorValue)
+    settingsGui_loadPhrases()
     GuiControl, SettingsGui:, SettingsGuiStatus,
+}
+
+settingsGui_loadPhrases(){
+    global CLSets, settingsGuiPhrases
+
+    settingsGuiPhrases:=[]
+    if(IsObject(CLSets) && IsObject(CLSets.TabHotString))
+    {
+        for key,value in CLSets.TabHotString
+        {
+            settingsGuiPhrases.Push({trigger:key, replacement:settingsGui_decodePhraseValue(value)})
+        }
+    }
+    settingsGui_refreshPhraseList()
+    GuiControl, SettingsGui:, SettingsPhraseTrigger,
+    GuiControl, SettingsGui:, SettingsPhraseReplacement,
+}
+
+settingsGui_refreshPhraseList(selectRow:=0){
+    global settingsGuiPhrases
+
+    Gui, SettingsGui:ListView, SettingsPhraseListView
+    LV_Delete()
+    for index,phrase in settingsGuiPhrases
+        LV_Add("", phrase.trigger, phrase.replacement)
+    LV_ModifyCol(1, 245)
+    LV_ModifyCol(2, 245)
+    if(selectRow && selectRow<=settingsGuiPhrases.MaxIndex())
+        LV_Modify(selectRow, "Select Focus")
+}
+
+settingsGui_phraseSelection(){
+    Gui, SettingsGui:ListView, SettingsPhraseListView
+    return LV_GetNext(0)
+}
+
+settingsGui_validatePhrase(trigger, replacement, currentRow:=0){
+    global settingsGuiPhrases
+
+    trigger:=Trim(trigger)
+    if(trigger="")
+    {
+        message:=isLangChinese() ? "请输入触发词。" : "Enter a trigger."
+        MsgBox, 0x40030, CapsLock+, %message%
+        GuiControl, SettingsGui:Focus, SettingsPhraseTrigger
+        return false
+    }
+    if(InStr(trigger, "=") || InStr(trigger, "`n") || InStr(trigger, "`r"))
+    {
+        message:=isLangChinese() ? "触发词不能包含等号或换行。" : "A trigger cannot contain '=' or a line break."
+        MsgBox, 0x40030, CapsLock+, %message%
+        GuiControl, SettingsGui:Focus, SettingsPhraseTrigger
+        return false
+    }
+    if(replacement="")
+    {
+        message:=isLangChinese() ? "请输入替换内容。" : "Enter replacement text."
+        MsgBox, 0x40030, CapsLock+, %message%
+        GuiControl, SettingsGui:Focus, SettingsPhraseReplacement
+        return false
+    }
+    for index,phrase in settingsGuiPhrases
+    {
+        if(index!=currentRow && phrase.trigger=trigger)
+        {
+            message:=isLangChinese() ? "这个触发词已经存在。" : "That trigger already exists."
+            MsgBox, 0x40030, CapsLock+, %message%
+            GuiControl, SettingsGui:Focus, SettingsPhraseTrigger
+            return false
+        }
+    }
+    return true
+}
+
+settingsGui_phraseLoadSelected(){
+    global settingsGuiPhrases
+
+    row:=settingsGui_phraseSelection()
+    if(!row || !IsObject(settingsGuiPhrases[row]))
+        return
+    GuiControl, SettingsGui:, SettingsPhraseTrigger, % settingsGuiPhrases[row].trigger
+    GuiControl, SettingsGui:, SettingsPhraseReplacement, % settingsGuiPhrases[row].replacement
+}
+
+settingsGui_phraseAdd(){
+    global settingsGuiPhrases
+
+    GuiControlGet, trigger, SettingsGui:, SettingsPhraseTrigger
+    GuiControlGet, replacement, SettingsGui:, SettingsPhraseReplacement
+    if(!settingsGui_validatePhrase(trigger, replacement))
+        return
+    settingsGuiPhrases.Push({trigger:Trim(trigger), replacement:replacement})
+    settingsGui_refreshPhraseList()
+    Gui, SettingsGui:ListView, SettingsPhraseListView
+    LV_Modify(0, "-Select -Focus")
+    GuiControl, SettingsGui:, SettingsPhraseTrigger,
+    GuiControl, SettingsGui:, SettingsPhraseReplacement,
+    GuiControl, SettingsGui:Focus, SettingsPhraseTrigger
+    GuiControl, SettingsGui:, SettingsGuiStatus,
+}
+
+settingsGui_phraseDelete(){
+    global settingsGuiPhrases
+
+    row:=settingsGui_phraseSelection()
+    if(!row || !IsObject(settingsGuiPhrases[row]))
+    {
+        message:=isLangChinese() ? "请先选择要删除的常用语。" : "Select a phrase to delete first."
+        MsgBox, 0x40030, CapsLock+, %message%
+        return
+    }
+    settingsGuiPhrases.Remove(row)
+    settingsGui_refreshPhraseList()
+    GuiControl, SettingsGui:, SettingsPhraseTrigger,
+    GuiControl, SettingsGui:, SettingsPhraseReplacement,
+}
+
+settingsGui_encodePhraseValue(value){
+    StringReplace, normalized, value, `r`n, `n, All
+    StringReplace, normalized, normalized, `r, , All
+    StringReplace, encoded, normalized, \n, \`n, All
+    StringReplace, encoded, encoded, `n, \n, All
+    return encoded
+}
+
+settingsGui_decodePhraseValue(value){
+    StringReplace, decoded, value, \n, `n, All
+    StringReplace, decoded, decoded, \`n, \n, All
+    return decoded
+}
+
+settingsGui_applyPhraseEditor(){
+    global settingsGuiPhrases
+
+    row:=settingsGui_phraseSelection()
+    if(!row || !IsObject(settingsGuiPhrases[row]))
+        return true
+    GuiControlGet, trigger, SettingsGui:, SettingsPhraseTrigger
+    GuiControlGet, replacement, SettingsGui:, SettingsPhraseReplacement
+    if(!settingsGui_validatePhrase(trigger, replacement, row))
+        return false
+    settingsGuiPhrases[row].trigger:=Trim(trigger)
+    settingsGuiPhrases[row].replacement:=replacement
+    settingsGui_refreshPhraseList(row)
+    return true
+}
+
+settingsGui_savePhrases(){
+    global CLSets, settingsGuiPhrases
+
+    if(!settingsGui_applyPhraseEditor())
+        return false
+    if(!IsObject(CLSets.TabHotString))
+        CLSets.TabHotString:={}
+    for key,value in CLSets.TabHotString
+        IniDelete, CapsLock+settings.ini, TabHotString, %key%
+
+    CLSets.TabHotString:={}
+    if(!IsObject(CLSets.length))
+        CLSets.length:={}
+    CLSets.length.TabHotString:=0
+    for index,phrase in settingsGuiPhrases
+    {
+        encodedValue:=settingsGui_encodePhraseValue(phrase.replacement)
+        phraseTrigger:=phrase.trigger
+        IniWrite, %encodedValue%, CapsLock+settings.ini, TabHotString, %phraseTrigger%
+        CLSets.TabHotString[phraseTrigger]:=encodedValue
+        CLSets.length.TabHotString++
+    }
+    SetTimer, hotStringInit, -1
+    savedText:=isLangChinese() ? "常用语已保存并立即生效。" : "Phrases saved and applied."
+    GuiControl, SettingsGui:, SettingsGuiStatus, %savedText%
+    return true
+}
+
+settingsGui_cleanupConfigDefaults(){
+    global CLSets
+
+    ; Qbar 样式现在完全使用 lib_clQ 的内置回退值，删除旧配置中的所有样式键。
+    styleHasValues:=false
+    if(IsObject(CLSets) && IsObject(CLSets.QStyle))
+    {
+        for key,value in CLSets.QStyle
+        {
+            styleHasValues:=true
+            break
+        }
+    }
+    if(styleHasValues)
+        settingsGui_restoreQbarDefaults()
+
+    if(!IsObject(CLSets) || !IsObject(CLSets.Global))
+        return
+
+    if(CLSets.Global.autostart="0")
+        IniDelete, CapsLock+settings.ini, Global, autostart
+    if(CLSets.Global.loadingAnimation="1")
+        IniDelete, CapsLock+settings.ini, Global, loadingAnimation
+    if(CLSets.Global.allowClipboard="1")
+        IniDelete, CapsLock+settings.ini, Global, allowClipboard
+    if(CLSets.Global.mouseSpeed="3")
+        IniDelete, CapsLock+settings.ini, Global, mouseSpeed
+    if(CLSets.Global.default_hotkey_scheme="capslox")
+        IniDelete, CapsLock+settings.ini, Global, default_hotkey_scheme
+    if(CLSets.Global.winPinSoundEnabled="1")
+        IniDelete, CapsLock+settings.ini, Global, winPinSoundEnabled
+    if(CLSets.Global.winPinSoundFile="")
+        IniDelete, CapsLock+settings.ini, Global, winPinSoundFile
+    if(CLSets.Global.qbarExternalApp="builtin")
+        IniDelete, CapsLock+settings.ini, Global, qbarExternalApp
+
+    if(CLSets.Global.winPinBorderColor!=""
+        && winPinBorder_tryParseColor(CLSets.Global.winPinBorderColor, normalizedColor)
+        && normalizedColor="00ADEF")
+        IniDelete, CapsLock+settings.ini, Global, winPinBorderColor
+
+    externalPath:=CLSets.Global.externalAppPath
+    if(externalPath="")
+        externalPath:=CLSets.Global.listaryPath
+    if(externalPath!="")
+    {
+        if(CLSets.Global.externalAppPath="")
+        {
+            IniWrite, %externalPath%, CapsLock+settings.ini, Global, externalAppPath
+            CLSets.Global.externalAppPath:=externalPath
+        }
+    }
+    else
+        IniDelete, CapsLock+settings.ini, Global, externalAppPath
+
+    if(CLSets.Global.qbarExternalApp="listary")
+    {
+        IniWrite, external, CapsLock+settings.ini, Global, qbarExternalApp
+        CLSets.Global.qbarExternalApp:="external"
+    }
+    else if(CLSets.Global.qbarExternalApp="" && IsObject(CLSets.Keys)
+        && (InStr(CLSets.Keys.caps_q, "qbarListary") || InStr(CLSets.Keys.caps_q, "qbarExternalApp") || InStr(CLSets.Keys.caps_q, "listary")))
+    {
+        IniWrite, external, CapsLock+settings.ini, Global, qbarExternalApp
+        CLSets.Global.qbarExternalApp:="external"
+    }
+    IniDelete, CapsLock+settings.ini, Global, listaryPath
+    keysSet_applyQbarExternalApp()
 }
 
 settingsGui_setPage(page){
     global settingsGuiPage
 
-    generalControls:="SettingsGeneralTitle|SettingsGeneralDescription|SettingsAutostart|SettingsLoadingAnimation|SettingsAllowClipboard|SettingsMouseSpeedLabel|SettingsMouseSpeed|SettingsSchemeLabel|SettingsHotkeyScheme"
+    generalControls:="SettingsGeneralTitle|SettingsGeneralDescription|SettingsAutostart|SettingsLoadingAnimation|SettingsAllowClipboard|SettingsMouseSpeedLabel|SettingsMouseSpeed"
+    hotkeysControls:="SettingsHotkeysTitle|SettingsHotkeysDescription|SettingsSchemeLabel|SettingsHotkeyScheme|SettingsHotkeysHint"
     pinControls:="SettingsPinTitle|SettingsPinDescription|SettingsPinColorLabel|SettingsPinColorPreview|SettingsPinColorEdit|SettingsPinChooseColor|SettingsPinColorHint|SettingsPinSoundEnabled|SettingsPinSoundFileLabel|SettingsPinSoundFile|SettingsPinChooseSound|SettingsPinSoundDefaultHint"
-    qbarControls:="SettingsQbarTitle|SettingsQbarDescription|SettingsQbarExternalAppLabel|SettingsQbarExternalApp|SettingsQbarExternalAppHint"
+    qbarControls:="SettingsQbarTitle|SettingsQbarDescription|SettingsQbarExternalAppLabel|SettingsQbarExternalApp|SettingsQbarExternalAppHint|SettingsQbarExternalPathLabel|SettingsQbarExternalPath|SettingsQbarChooseExternalPath|SettingsQbarExternalPathHint"
+    phrasesControls:="SettingsPhrasesTitle|SettingsPhrasesDescription|SettingsPhraseListView|SettingsPhraseTriggerLabel|SettingsPhraseReplacementLabel|SettingsPhraseTrigger|SettingsPhraseReplacement|SettingsPhraseAddButton|SettingsPhraseDeleteButton"
     if(page="pin")
     {
         settingsGuiPage:="pin"
         for index,controlName in StrSplit(generalControls, "|")
             GuiControl, SettingsGui:Hide, %controlName%
+        for index,controlName in StrSplit(hotkeysControls, "|")
+            GuiControl, SettingsGui:Hide, %controlName%
         for index,controlName in StrSplit(qbarControls, "|")
+            GuiControl, SettingsGui:Hide, %controlName%
+        for index,controlName in StrSplit(phrasesControls, "|")
             GuiControl, SettingsGui:Hide, %controlName%
         for index,controlName in StrSplit(pinControls, "|")
             GuiControl, SettingsGui:Show, %controlName%
         GuiControl, SettingsGui:Hide, SettingsNavGeneralHighlight
         GuiControl, SettingsGui:Hide, SettingsNavQbarHighlight
+        GuiControl, SettingsGui:Hide, SettingsNavHotkeysHighlight
+        GuiControl, SettingsGui:Hide, SettingsNavPhrasesHighlight
         GuiControl, SettingsGui:Show, SettingsNavPinHighlight
         GuiControl, SettingsGui:+c89919D, SettingsNavGeneral
         GuiControl, SettingsGui:+cFFFFFF, SettingsNavPin
         GuiControl, SettingsGui:+c89919D, SettingsNavQbar
+        GuiControl, SettingsGui:+c89919D, SettingsNavHotkeys
+        GuiControl, SettingsGui:+c89919D, SettingsNavPhrases
     }
     else if(page="qbar")
     {
         settingsGuiPage:="qbar"
         for index,controlName in StrSplit(generalControls, "|")
             GuiControl, SettingsGui:Hide, %controlName%
+        for index,controlName in StrSplit(hotkeysControls, "|")
+            GuiControl, SettingsGui:Hide, %controlName%
         for index,controlName in StrSplit(pinControls, "|")
+            GuiControl, SettingsGui:Hide, %controlName%
+        for index,controlName in StrSplit(phrasesControls, "|")
             GuiControl, SettingsGui:Hide, %controlName%
         for index,controlName in StrSplit(qbarControls, "|")
             GuiControl, SettingsGui:Show, %controlName%
+        GuiControlGet, qbarSelection, SettingsGui:, SettingsQbarExternalApp
+        settingsGui_updateQbarExternalControls(qbarSelection=2)
         GuiControl, SettingsGui:Hide, SettingsNavGeneralHighlight
         GuiControl, SettingsGui:Hide, SettingsNavPinHighlight
+        GuiControl, SettingsGui:Hide, SettingsNavHotkeysHighlight
+        GuiControl, SettingsGui:Hide, SettingsNavPhrasesHighlight
         GuiControl, SettingsGui:Show, SettingsNavQbarHighlight
         GuiControl, SettingsGui:+c89919D, SettingsNavGeneral
         GuiControl, SettingsGui:+c89919D, SettingsNavPin
         GuiControl, SettingsGui:+cFFFFFF, SettingsNavQbar
+        GuiControl, SettingsGui:+c89919D, SettingsNavHotkeys
+        GuiControl, SettingsGui:+c89919D, SettingsNavPhrases
+    }
+    else if(page="hotkeys")
+    {
+        settingsGuiPage:="hotkeys"
+        for index,controlName in StrSplit(generalControls, "|")
+            GuiControl, SettingsGui:Hide, %controlName%
+        for index,controlName in StrSplit(pinControls, "|")
+            GuiControl, SettingsGui:Hide, %controlName%
+        for index,controlName in StrSplit(qbarControls, "|")
+            GuiControl, SettingsGui:Hide, %controlName%
+        for index,controlName in StrSplit(phrasesControls, "|")
+            GuiControl, SettingsGui:Hide, %controlName%
+        for index,controlName in StrSplit(hotkeysControls, "|")
+            GuiControl, SettingsGui:Show, %controlName%
+        GuiControl, SettingsGui:Hide, SettingsNavGeneralHighlight
+        GuiControl, SettingsGui:Hide, SettingsNavPinHighlight
+        GuiControl, SettingsGui:Hide, SettingsNavQbarHighlight
+        GuiControl, SettingsGui:Hide, SettingsNavPhrasesHighlight
+        GuiControl, SettingsGui:Show, SettingsNavHotkeysHighlight
+        GuiControl, SettingsGui:+c89919D, SettingsNavGeneral
+        GuiControl, SettingsGui:+c89919D, SettingsNavPin
+        GuiControl, SettingsGui:+c89919D, SettingsNavQbar
+        GuiControl, SettingsGui:+cFFFFFF, SettingsNavHotkeys
+        GuiControl, SettingsGui:+c89919D, SettingsNavPhrases
+    }
+    else if(page="phrases")
+    {
+        settingsGuiPage:="phrases"
+        for index,controlName in StrSplit(generalControls, "|")
+            GuiControl, SettingsGui:Hide, %controlName%
+        for index,controlName in StrSplit(pinControls, "|")
+            GuiControl, SettingsGui:Hide, %controlName%
+        for index,controlName in StrSplit(qbarControls, "|")
+            GuiControl, SettingsGui:Hide, %controlName%
+        for index,controlName in StrSplit(hotkeysControls, "|")
+            GuiControl, SettingsGui:Hide, %controlName%
+        for index,controlName in StrSplit(phrasesControls, "|")
+            GuiControl, SettingsGui:Show, %controlName%
+        GuiControl, SettingsGui:Hide, SettingsNavGeneralHighlight
+        GuiControl, SettingsGui:Hide, SettingsNavPinHighlight
+        GuiControl, SettingsGui:Hide, SettingsNavQbarHighlight
+        GuiControl, SettingsGui:Hide, SettingsNavHotkeysHighlight
+        GuiControl, SettingsGui:Show, SettingsNavPhrasesHighlight
+        GuiControl, SettingsGui:+c89919D, SettingsNavGeneral
+        GuiControl, SettingsGui:+c89919D, SettingsNavPin
+        GuiControl, SettingsGui:+c89919D, SettingsNavQbar
+        GuiControl, SettingsGui:+c89919D, SettingsNavHotkeys
+        GuiControl, SettingsGui:+cFFFFFF, SettingsNavPhrases
     }
     else
     {
         settingsGuiPage:="general"
         for index,controlName in StrSplit(pinControls, "|")
             GuiControl, SettingsGui:Hide, %controlName%
+        for index,controlName in StrSplit(hotkeysControls, "|")
+            GuiControl, SettingsGui:Hide, %controlName%
         for index,controlName in StrSplit(qbarControls, "|")
+            GuiControl, SettingsGui:Hide, %controlName%
+        for index,controlName in StrSplit(phrasesControls, "|")
             GuiControl, SettingsGui:Hide, %controlName%
         for index,controlName in StrSplit(generalControls, "|")
             GuiControl, SettingsGui:Show, %controlName%
         GuiControl, SettingsGui:Hide, SettingsNavPinHighlight
         GuiControl, SettingsGui:Hide, SettingsNavQbarHighlight
+        GuiControl, SettingsGui:Hide, SettingsNavHotkeysHighlight
+        GuiControl, SettingsGui:Hide, SettingsNavPhrasesHighlight
         GuiControl, SettingsGui:Show, SettingsNavGeneralHighlight
         GuiControl, SettingsGui:+cFFFFFF, SettingsNavGeneral
         GuiControl, SettingsGui:+c89919D, SettingsNavPin
         GuiControl, SettingsGui:+c89919D, SettingsNavQbar
+        GuiControl, SettingsGui:+c89919D, SettingsNavHotkeys
+        GuiControl, SettingsGui:+c89919D, SettingsNavPhrases
     }
     GuiControl, SettingsGui:, SettingsGuiStatus,
+}
+
+settingsGui_updateQbarExternalControls(showPath){
+    pathControls:="SettingsQbarExternalPathLabel|SettingsQbarExternalPath|SettingsQbarChooseExternalPath|SettingsQbarExternalPathHint"
+    for index,controlName in StrSplit(pathControls, "|")
+    {
+        if(showPath)
+            GuiControl, SettingsGui:Show, %controlName%
+        else
+            GuiControl, SettingsGui:Hide, %controlName%
+    }
 }
 
 settingsGui_updateColorPreview(colorValue){
@@ -322,10 +728,13 @@ settingsGui_updateColorPreview(colorValue){
 settingsGui_save(){
     global CLSets, settingsGuiPage, SettingsAutostart, SettingsLoadingAnimation, SettingsAllowClipboard, SettingsMouseSpeed, SettingsHotkeyScheme
     global SettingsPinColorEdit, SettingsPinSoundEnabled, SettingsPinSoundFile
-    global SettingsQbarExternalApp
-    global needInitQ
+    global SettingsQbarExternalApp, SettingsQbarExternalPath
+    global keyset
 
     Gui, SettingsGui:Submit, NoHide
+    oldHotkeyScheme:="capslox"
+    if(IsObject(CLSets) && IsObject(CLSets.Global) && CLSets.Global.default_hotkey_scheme="capslock_plus")
+        oldHotkeyScheme:="capslock_plus"
     colorValue:=Trim(SettingsPinColorEdit)
     if(!winPinBorder_tryParseColor(colorValue, normalizedColor))
     {
@@ -343,8 +752,22 @@ settingsGui_save(){
         return false
     }
 
-    qbarExternalApp:=SettingsQbarExternalApp=2 ? "listary" : "builtin"
-    qbarKeyValue:=qbarExternalApp="listary" ? "keyFunc_qbarListary" : "keyFunc_qbar"
+    qbarExternalApp:=SettingsQbarExternalApp=2 ? "external" : "builtin"
+    qbarKeyValue:=qbarExternalApp="external" ? "keyFunc_qbarExternalApp" : "keyFunc_qbar"
+    externalPath:=Trim(SettingsQbarExternalPath)
+    if(qbarExternalApp="external" && externalPath="")
+    {
+        message:=isLangChinese() ? "选择外部程序后必须填写程序路径。" : "Enter the external application's path before saving."
+        MsgBox, 0x40030, CapsLock+, %message%
+        GuiControl, SettingsGui:Focus, SettingsQbarExternalPath
+        return false
+    }
+    if(qbarExternalApp="external" && !FileExist(externalPath))
+    {
+        message:=isLangChinese() ? "外部程序路径不存在，请重新选择。" : "The external application's path does not exist. Choose it again."
+        MsgBox, 0x40030, CapsLock+, %message%
+        return false
+    }
 
     ; 内置 Qbar 不再暴露样式选项，切回内置模式时恢复项目原始样式。
     if(settingsGuiPage="qbar" && qbarExternalApp="builtin")
@@ -356,15 +779,21 @@ settingsGui_save(){
     mouseSpeed:=SettingsMouseSpeed
     hotkeyScheme:=SettingsHotkeyScheme=2 ? "capslock_plus" : "capslox"
 
-    IniWrite, %autostart%, CapsLock+settings.ini, Global, autostart
-    IniWrite, %loadingAnimation%, CapsLock+settings.ini, Global, loadingAnimation
-    IniWrite, %allowClipboard%, CapsLock+settings.ini, Global, allowClipboard
-    IniWrite, %mouseSpeed%, CapsLock+settings.ini, Global, mouseSpeed
-    IniWrite, %hotkeyScheme%, CapsLock+settings.ini, Global, default_hotkey_scheme
-    IniWrite, %colorValue%, CapsLock+settings.ini, Global, winPinBorderColor
-    IniWrite, %soundEnabled%, CapsLock+settings.ini, Global, winPinSoundEnabled
-    IniWrite, %soundFile%, CapsLock+settings.ini, Global, winPinSoundFile
-    IniWrite, %qbarExternalApp%, CapsLock+settings.ini, Global, qbarExternalApp
+    settingsGui_writeGlobalValue("autostart", autostart, 0)
+    settingsGui_writeGlobalValue("loadingAnimation", loadingAnimation, 1)
+    settingsGui_writeGlobalValue("allowClipboard", allowClipboard, 1)
+    settingsGui_writeGlobalValue("mouseSpeed", mouseSpeed, 3)
+    settingsGui_writeGlobalValue("default_hotkey_scheme", hotkeyScheme, "capslox")
+    if(normalizedColor="00ADEF")
+        IniDelete, CapsLock+settings.ini, Global, winPinBorderColor
+    else
+        IniWrite, %colorValue%, CapsLock+settings.ini, Global, winPinBorderColor
+    settingsGui_writeGlobalValue("winPinSoundEnabled", soundEnabled, 1)
+    settingsGui_writeGlobalValue("winPinSoundFile", soundFile, "")
+    settingsGui_writeGlobalValue("qbarExternalApp", qbarExternalApp, "builtin")
+    settingsGui_writeGlobalValue("externalAppPath", externalPath, "")
+    IniDelete, CapsLock+settings.ini, Global, listaryPath
+    ; 显式保存 CapsLock+Q 的路由，避免删除默认键后旧运行实例仍保留外部程序路由。
     IniWrite, %qbarKeyValue%, CapsLock+settings.ini, Keys, caps_q
 
     if(!IsObject(CLSets.Global))
@@ -378,10 +807,20 @@ settingsGui_save(){
     CLSets.Global.winPinSoundEnabled:=soundEnabled
     CLSets.Global.winPinSoundFile:=soundFile
     CLSets.Global.qbarExternalApp:=qbarExternalApp
+    CLSets.Global.externalAppPath:=externalPath
+    ; 两套布局会为缺失按键补不同的默认值。切换布局时必须先从 INI
+    ; 重新建立 Keys 对象，否则旧布局已经补齐的值会阻止新布局生效。
+    if(oldHotkeyScheme!=hotkeyScheme)
+    {
+        CLSets.length.Keys:=""
+        settingsSectionInit("Keys")
+    }
     if(!IsObject(CLSets.Keys))
         CLSets.Keys:={}
     CLSets.Keys.caps_q:=qbarKeyValue
-    needInitQ:=1
+    if(IsObject(keyset))
+        keyset.caps_q:=qbarKeyValue
+    keysSet_applyQbarExternalApp()
     winPinBorder_refreshSettings()
     settingsGui_updateColorPreview(colorValue)
     if(IsLabel("globalSettings"))
@@ -394,6 +833,8 @@ settingsGui_save(){
         settingsTimerLabel:="keysInit"
         SetTimer, %settingsTimerLabel%, -1
     }
+    ; keysInit 可能会被设置文件监控延后触发，再补一次路由同步，确保切换后无需 F5。
+    SetTimer, settingsGuiApplyQbarRoute, -120
     if(IsLabel("mouseSpeedInit"))
     {
         settingsTimerLabel:="mouseSpeedInit"
@@ -401,26 +842,34 @@ settingsGui_save(){
     }
 
     if(settingsGuiPage="qbar")
-        savedText:=isLangChinese() ? "设置已保存，Qbar 下次打开时应用。" : "Saved. Qbar will apply it next time it opens."
+        savedText:=isLangChinese() ? "设置已保存，Qbar 路由已立即切换。" : "Saved. Qbar routing switched immediately."
     else
         savedText:=isLangChinese() ? "设置已保存并立即生效。" : "Settings saved and applied."
     GuiControl, SettingsGui:, SettingsGuiStatus, %savedText%
     return true
 }
 
+settingsGui_writeGlobalValue(key, value, defaultValue){
+    if(value=defaultValue)
+        IniDelete, CapsLock+settings.ini, Global, %key%
+    else
+        IniWrite, %value%, CapsLock+settings.ini, Global, %key%
+}
+
 settingsGui_restoreQbarDefaults(){
     global CLSets, needInitQ
-    ; 这些值来自 lib_clQ 原有的内置回退值，而不是设置示例里的红/绿/蓝配色。
-    defaults:={borderBackgroundColor:"555555", borderRadius:2, textBackgroundColor:"EE2255", textColor:"FFFFFF"
-        , textFontName:"", textFontSize:12, listFontName:"", listFontSize:10
-        , listBackgroundColor:"333333", listColor:"FFFFFF", listCount:10, lineHeight:19, progressColor:"11DDAA"}
-    for key,value in defaults
-        IniWrite, %value%, CapsLock+settings.ini, QStyle, %key%
-    if(!IsObject(CLSets.QStyle))
-        CLSets.QStyle:={}
-    for key,value in defaults
-        CLSets.QStyle[key]:=value
-    needInitQ:=1
+    styleChanged:=false
+    if(IsObject(CLSets.QStyle))
+    {
+        for key,value in CLSets.QStyle
+        {
+            IniDelete, CapsLock+settings.ini, QStyle, %key%
+            styleChanged:=true
+        }
+    }
+    CLSets.QStyle:={}
+    if(styleChanged)
+        needInitQ:=1
 }
 
 settingsGui_chooseColor(ownerHwnd, initialColor){
@@ -483,6 +932,46 @@ SettingsGuiShowQbar:
 settingsGui_setPage("qbar")
 return
 
+SettingsGuiShowHotkeys:
+settingsGui_setPage("hotkeys")
+return
+
+SettingsGuiShowPhrases:
+settingsGui_setPage("phrases")
+return
+
+SettingsGuiPhraseListChanged:
+settingsGui_phraseLoadSelected()
+return
+
+SettingsGuiPhraseAdd:
+settingsGui_phraseAdd()
+return
+
+SettingsGuiPhraseDelete:
+settingsGui_phraseDelete()
+return
+
+SettingsGuiQbarExternalChanged:
+GuiControlGet, qbarSelection, SettingsGui:, SettingsQbarExternalApp
+settingsGui_updateQbarExternalControls(qbarSelection=2)
+return
+
+settingsGuiApplyQbarRoute:
+keysSet_applyQbarExternalApp()
+return
+
+SettingsGuiChooseExternalPath:
+GuiControlGet, currentExternalPath, SettingsGui:, SettingsQbarExternalPath
+externalStartDirectory:=A_ProgramFiles
+if(currentExternalPath!="" && FileExist(currentExternalPath))
+    SplitPath, currentExternalPath, , externalStartDirectory
+externalDialogTitle:=isLangChinese() ? "选择外部程序" : "Choose external application"
+FileSelectFile, selectedExternalPath, 1, %externalStartDirectory%, %externalDialogTitle%, Applications (*.exe)
+if(selectedExternalPath!="")
+    GuiControl, SettingsGui:, SettingsQbarExternalPath, %selectedExternalPath%
+return
+
 SettingsGuiChooseSound:
 GuiControlGet, currentSoundFile, SettingsGui:, SettingsPinSoundFile
 soundStartDirectory:=A_WinDir . "\Media"
@@ -505,6 +994,19 @@ if(settingsGuiPage="pin")
 else if(settingsGuiPage="qbar")
 {
     GuiControl, SettingsGui:Choose, SettingsQbarExternalApp, 1
+    GuiControl, SettingsGui:, SettingsQbarExternalPath,
+    settingsGui_updateQbarExternalControls(false)
+}
+else if(settingsGuiPage="hotkeys")
+{
+    GuiControl, SettingsGui:Choose, SettingsHotkeyScheme, 1
+}
+else if(settingsGuiPage="phrases")
+{
+    settingsGuiPhrases:=[]
+    settingsGui_refreshPhraseList()
+    GuiControl, SettingsGui:, SettingsPhraseTrigger,
+    GuiControl, SettingsGui:, SettingsPhraseReplacement,
 }
 else
 {
@@ -512,13 +1014,15 @@ else
     GuiControl, SettingsGui:, SettingsLoadingAnimation, 1
     GuiControl, SettingsGui:, SettingsAllowClipboard, 1
     GuiControl, SettingsGui:Choose, SettingsMouseSpeed, 3
-    GuiControl, SettingsGui:Choose, SettingsHotkeyScheme, 1
 }
 GuiControl, SettingsGui:, SettingsGuiStatus,
 return
 
 SettingsGuiSave:
-settingsGui_save()
+if(settingsGuiPage="phrases")
+    settingsGui_savePhrases()
+else
+    settingsGui_save()
 return
 
 SettingsGuiOpenAdvanced:
@@ -528,5 +1032,7 @@ return
 SettingsGuiCancel:
 SettingsGuiClose:
 SettingsGuiEscape:
+if(settingsGuiPage="qbar")
+    keysSet_applyQbarExternalApp()
 Gui, SettingsGui:Hide
 return

--- a/lib/lib_winPinBorder.ahk
+++ b/lib/lib_winPinBorder.ahk
@@ -2,27 +2,48 @@
 ; 边框由一个中间镂空、不激活、鼠标穿透的工具窗口组成，不会影响目标窗口操作。
 
 global winPinBorders:={}
+global winPinBorderGuiNames:={}
 global winPinBorderSizes:={}
 global winPinBorderPositions:={}
+global winPinBorderVisibility:={}
+global winPinBorderFrameMetrics:={}
 global winPinBorderWinIds:=[]
 global winPinBorderColor:="00ADEF"
 global winPinBorderWidth:=6
+global winPinBorderSyncInterval:=0
+global winPinBorderIdleTicks:=0
+global winPinBorderActiveInterval:=15
+global winPinBorderIdleInterval:=50
+global winPinCustomSoundFile:=""
 
 winPinBorder_add(winId){
-    global winPinBorders, winPinBorderColor, winPinBorderSizes, winPinBorderPositions, winPinBorderWinIds, winPinBorderWidth
+    global winPinBorders, winPinBorderGuiNames, winPinBorderColor, winPinBorderSizes, winPinBorderPositions, winPinBorderVisibility, winPinBorderFrameMetrics, winPinBorderWinIds, winPinBorderWidth, winPinBorderActiveInterval, winPinBorderIdleInterval, winPinBorderIdleTicks
 
     if(!IsObject(winPinBorders))
         winPinBorders:={}
+    if(!IsObject(winPinBorderGuiNames))
+        winPinBorderGuiNames:={}
     if(!IsObject(winPinBorderSizes))
         winPinBorderSizes:={}
     if(!IsObject(winPinBorderPositions))
         winPinBorderPositions:={}
+    if(!IsObject(winPinBorderVisibility))
+        winPinBorderVisibility:={}
+    if(!IsObject(winPinBorderFrameMetrics))
+        winPinBorderFrameMetrics:={}
     if(!IsObject(winPinBorderWinIds))
         winPinBorderWinIds:=[]
     if(winPinBorderColor="")
         winPinBorderColor:="00ADEF"
     if(winPinBorderWidth="")
         winPinBorderWidth:=6
+    if(winPinBorderActiveInterval="")
+        winPinBorderActiveInterval:=15
+    if(winPinBorderIdleInterval="")
+        winPinBorderIdleInterval:=50
+    if(winPinBorderIdleTicks="")
+        winPinBorderIdleTicks:=0
+    winPinBorder_refreshSettings()
     if(!DllCall("IsWindow", "Ptr", winId))
         return false
 
@@ -36,12 +57,10 @@ winPinBorder_add(winId){
     y:=rect.y
     w:=rect.w
     h:=rect.h
-    dpi:=DllCall("User32\GetDpiForWindow", "Ptr", winId, "UInt")
-    if(!dpi)
-        dpi:=A_ScreenDPI
+    dpi:=rect.dpi
     thickness:=Max(2, Round(winPinBorderWidth*dpi/96))
 
-    guiName:="WinPinBorder_" . winId
+    guiName:="WinPinBorder_" . Format("{:d}", winId+0)
     Gui, %guiName%:New, +HwndborderHwnd -Caption +ToolWindow +AlwaysOnTop +E0x20 +E0x08000000
     Gui, %guiName%:Color, %winPinBorderColor%
 
@@ -52,29 +71,36 @@ winPinBorder_add(winId){
     if(A_PtrSize!=8)
         DllCall("User32\SetWindowLong", "Ptr", borderHwnd, "Int", -8, "Ptr", winId, "Ptr")
 
-    Gui, %guiName%:Show, NA x%x% y%y% w%w% h%h%
+    showOptions:="NA x" . Format("{:d}", x) . " y" . Format("{:d}", y) . " w" . Format("{:d}", w) . " h" . Format("{:d}", h)
+    Gui, %guiName%:Show, %showOptions%
     winPinBorder_setRegion(borderHwnd, w, h, thickness)
 
     winPinBorders[winId]:=borderHwnd
+    winPinBorderGuiNames[winId]:=guiName
     winPinBorderSizes[winId]:=w . "|" . h . "|" . thickness
     winPinBorderPositions[winId]:=x . "|" . y . "|" . w . "|" . h
+    winPinBorderVisibility[winId]:=true
     winPinBorderWinIds.Push(winId)
-    SetTimer, winPinBorderSyncTimer, 10
+    winPinBorderIdleTicks:=0
+    winPinBorder_setTimerInterval(winPinBorderActiveInterval)
     return true
 }
 
 winPinBorder_remove(winId){
-    global winPinBorders, winPinBorderSizes, winPinBorderPositions, winPinBorderWinIds
+    global winPinBorders, winPinBorderGuiNames, winPinBorderSizes, winPinBorderPositions, winPinBorderVisibility, winPinBorderWinIds, winPinBorderSyncInterval
 
     if(!winPinBorders.HasKey(winId))
         return
 
     borderHwnd:=winPinBorders[winId]
-    Gui, %borderHwnd%:Destroy
+    guiName:=winPinBorderGuiNames[winId]
+    Gui, %guiName%:Destroy
 
     winPinBorders.Delete(winId)
+    winPinBorderGuiNames.Delete(winId)
     winPinBorderSizes.Delete(winId)
     winPinBorderPositions.Delete(winId)
+    winPinBorderVisibility.Delete(winId)
     Loop, % winPinBorderWinIds.Length()
     {
         if(winPinBorderWinIds[A_Index]=winId)
@@ -84,7 +110,107 @@ winPinBorder_remove(winId){
         }
     }
     if(!winPinBorders.Count())
+    {
         SetTimer, winPinBorderSyncTimer, Off
+        winPinBorderSyncInterval:=0
+    }
+}
+
+winPinBorder_setTimerInterval(interval){
+    global winPinBorderSyncInterval, winPinBorderIdleTicks
+
+    if(winPinBorderSyncInterval=interval)
+        return
+    winPinBorderSyncInterval:=interval
+    if(interval>0)
+        SetTimer, winPinBorderSyncTimer, %interval%
+    else
+        SetTimer, winPinBorderSyncTimer, Off
+    if(interval>0)
+        winPinBorderIdleTicks:=0
+}
+
+winPinBorder_parseColor(value){
+    if(winPinBorder_tryParseColor(value, normalizedColor))
+        return normalizedColor
+    return "00ADEF"
+}
+
+winPinBorder_tryParseColor(value, ByRef normalizedColor){
+    value:=Trim(value)
+    if(RegExMatch(value, "i)^(?:#|0x)?([0-9a-f]{6})$", colorMatch))
+    {
+        StringUpper, normalizedColor, colorMatch1
+        return true
+    }
+
+    if(RegExMatch(value, "^\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*$", rgbMatch))
+    {
+        red:=rgbMatch1+0
+        green:=rgbMatch2+0
+        blue:=rgbMatch3+0
+        if(red<=255 && green<=255 && blue<=255)
+        {
+            normalizedColor:=Format("{:02X}{:02X}{:02X}", red, green, blue)
+            return true
+        }
+    }
+    normalizedColor:=""
+    return false
+}
+
+winPinBorder_refreshSettings(){
+    global CLSets, winPinBorderColor, winPinBorders, winPinBorderGuiNames
+
+    if(!IsObject(winPinBorders))
+        winPinBorders:={}
+    if(!IsObject(winPinBorderGuiNames))
+        winPinBorderGuiNames:={}
+
+    configuredColor:=""
+    if(IsObject(CLSets) && IsObject(CLSets.Global))
+        configuredColor:=CLSets.Global.winPinBorderColor
+    newColor:=winPinBorder_parseColor(configuredColor)
+    if(newColor=winPinBorderColor)
+        return
+
+    winPinBorderColor:=newColor
+    for winId,borderHwnd in winPinBorders
+    {
+        guiName:=winPinBorderGuiNames[winId]
+        Gui, %guiName%:Color, %winPinBorderColor%
+        DllCall("User32\RedrawWindow", "Ptr", borderHwnd, "Ptr", 0, "Ptr", 0, "UInt", 0x105)
+    }
+}
+
+winPin_playSound(isPinned, force:=false){
+    static pinSoundFile:=A_WinDir . "\Media\Speech On.wav"
+    static unpinSoundFile:=A_WinDir . "\Media\Speech Sleep.wav"
+    global CLSets, winPinCustomSoundFile
+
+    if(!force && IsObject(CLSets) && IsObject(CLSets.Global) && CLSets.Global.winPinSoundEnabled="0")
+        return false
+
+    configuredSoundFile:=""
+    if(IsObject(CLSets) && IsObject(CLSets.Global))
+        configuredSoundFile:=Trim(CLSets.Global.winPinSoundFile)
+    if(configuredSoundFile!=winPinCustomSoundFile)
+        winPinCustomSoundFile:=configuredSoundFile
+
+    if(winPinCustomSoundFile!="" && FileExist(winPinCustomSoundFile))
+        return DllCall("Winmm\PlaySoundW", "WStr", winPinCustomSoundFile, "Ptr", 0, "UInt", 0x20003)
+
+    ; 异步播放期间路径缓冲区必须保持有效，因此直接传入静态变量。
+    if(isPinned)
+    {
+        if(!FileExist(pinSoundFile))
+            return false
+        return DllCall("Winmm\PlaySoundW", "WStr", pinSoundFile, "Ptr", 0, "UInt", 0x20003)
+    }
+
+    if(!FileExist(unpinSoundFile))
+        return false
+    return DllCall("Winmm\PlaySoundW", "WStr", unpinSoundFile, "Ptr", 0, "UInt", 0x20003)
 }
 
 winPinBorder_setRegion(borderHwnd, w, h, thickness){
@@ -109,6 +235,7 @@ winPinBorder_shouldShow(winId){
 
 winPinBorder_getRect(winId){
     static rectBuffer
+    global winPinBorderFrameMetrics
 
     VarSetCapacity(rectBuffer, 16, 0)
     if(!DllCall("User32\GetWindowRect", "Ptr", winId, "Ptr", &rectBuffer))
@@ -120,21 +247,26 @@ winPinBorder_getRect(winId){
     if(rectW<=0 || rectH<=0)
         return false
 
+    dpi:=DllCall("User32\GetDpiForWindow", "Ptr", winId, "UInt")
+    if(!dpi)
+        dpi:=A_ScreenDPI
+
     ; Win10/11 会在可缩放窗口四周保留一圈不可见的调整边距。
     ; 按系统边框指标向内修正，避免可见边框与窗口之间出现空隙。
     windowStyle:=DllCall("User32\GetWindowLongPtr", "Ptr", winId, "Int", -16, "Ptr")
     if(windowStyle & 0x40000) ; WS_THICKFRAME
     {
-        dpi:=DllCall("User32\GetDpiForWindow", "Ptr", winId, "UInt")
-        if(!dpi)
-            dpi:=A_ScreenDPI
-        frameX:=DllCall("User32\GetSystemMetricsForDpi", "Int", 32, "UInt", dpi, "Int")
-        frameY:=DllCall("User32\GetSystemMetricsForDpi", "Int", 33, "UInt", dpi, "Int")
-        padded:=DllCall("User32\GetSystemMetricsForDpi", "Int", 92, "UInt", dpi, "Int")
+        if(!winPinBorderFrameMetrics.HasKey(dpi))
+        {
+            frameX:=DllCall("User32\GetSystemMetricsForDpi", "Int", 32, "UInt", dpi, "Int")
+            frameY:=DllCall("User32\GetSystemMetricsForDpi", "Int", 33, "UInt", dpi, "Int")
+            padded:=DllCall("User32\GetSystemMetricsForDpi", "Int", 92, "UInt", dpi, "Int")
+            winPinBorderFrameMetrics[dpi]:={x:frameX+padded, y:frameY+padded}
+        }
+        frameX:=winPinBorderFrameMetrics[dpi].x
+        frameY:=winPinBorderFrameMetrics[dpi].y
         if(frameX>0 && frameY>0)
         {
-            frameX+=padded
-            frameY+=padded
             rectX+=frameX
             rectW-=2*frameX
             rectH-=frameY
@@ -143,7 +275,7 @@ winPinBorder_getRect(winId){
 
     if(rectW<=0 || rectH<=0)
         return false
-    return {x:rectX, y:rectY, w:rectW, h:rectH}
+    return {x:rectX, y:rectY, w:rectW, h:rectH, dpi:dpi}
 }
 
 winPinBorder_show(borderHwnd, show){
@@ -152,6 +284,7 @@ winPinBorder_show(borderHwnd, show){
 }
 
 winPinBorderSyncTimer:
+winPinBorderSyncChanged:=false
 winPinBorderSyncIndex:=winPinBorderWinIds.Length()
 while(winPinBorderSyncIndex>=1)
 {
@@ -172,10 +305,21 @@ while(winPinBorderSyncIndex>=1)
     }
 
     winPinBorderSyncHwnd:=winPinBorders[winPinBorderSyncWinId]
-    winPinBorderSyncRect:=winPinBorder_getRect(winPinBorderSyncWinId)
-    if(!winPinBorder_shouldShow(winPinBorderSyncWinId) || !IsObject(winPinBorderSyncRect))
+    if(!winPinBorder_shouldShow(winPinBorderSyncWinId))
     {
-        DllCall("User32\ShowWindow", "Ptr", winPinBorderSyncHwnd, "Int", 0)
+        if(winPinBorderVisibility[winPinBorderSyncWinId])
+        {
+            DllCall("User32\ShowWindow", "Ptr", winPinBorderSyncHwnd, "Int", 0)
+            winPinBorderVisibility[winPinBorderSyncWinId]:=false
+            winPinBorderSyncChanged:=true
+        }
+        winPinBorderSyncIndex--
+        continue
+    }
+
+    winPinBorderSyncRect:=winPinBorder_getRect(winPinBorderSyncWinId)
+    if(!IsObject(winPinBorderSyncRect))
+    {
         winPinBorderSyncIndex--
         continue
     }
@@ -184,9 +328,7 @@ while(winPinBorderSyncIndex>=1)
     winPinBorderSyncY:=winPinBorderSyncRect.y
     winPinBorderSyncW:=winPinBorderSyncRect.w
     winPinBorderSyncH:=winPinBorderSyncRect.h
-    winPinBorderSyncDpi:=DllCall("User32\GetDpiForWindow", "Ptr", winPinBorderSyncWinId, "UInt")
-    if(!winPinBorderSyncDpi)
-        winPinBorderSyncDpi:=A_ScreenDPI
+    winPinBorderSyncDpi:=winPinBorderSyncRect.dpi
     winPinBorderSyncThickness:=Max(2, Round(winPinBorderWidth*winPinBorderSyncDpi/96))
 
     winPinBorderSyncPositionKey:=winPinBorderSyncX . "|" . winPinBorderSyncY . "|" . winPinBorderSyncW . "|" . winPinBorderSyncH
@@ -194,16 +336,33 @@ while(winPinBorderSyncIndex>=1)
     {
         DllCall("User32\MoveWindow", "Ptr", winPinBorderSyncHwnd+0, "Int", winPinBorderSyncX, "Int", winPinBorderSyncY, "Int", winPinBorderSyncW, "Int", winPinBorderSyncH, "Int", true)
         winPinBorderPositions[winPinBorderSyncWinId]:=winPinBorderSyncPositionKey
+        winPinBorderSyncChanged:=true
     }
-    if(!DllCall("User32\IsWindowVisible", "Ptr", winPinBorderSyncHwnd+0))
+    if(!winPinBorderVisibility[winPinBorderSyncWinId])
+    {
         DllCall("User32\ShowWindow", "Ptr", winPinBorderSyncHwnd+0, "Int", 8)
+        winPinBorderVisibility[winPinBorderSyncWinId]:=true
+        winPinBorderSyncChanged:=true
+    }
 
     winPinBorderSyncSizeKey:=winPinBorderSyncW . "|" . winPinBorderSyncH . "|" . winPinBorderSyncThickness
     if(winPinBorderSizes[winPinBorderSyncWinId]!=winPinBorderSyncSizeKey)
     {
         winPinBorder_setRegion(winPinBorderSyncHwnd, winPinBorderSyncW, winPinBorderSyncH, winPinBorderSyncThickness)
         winPinBorderSizes[winPinBorderSyncWinId]:=winPinBorderSyncSizeKey
+        winPinBorderSyncChanged:=true
     }
     winPinBorderSyncIndex--
+}
+if(winPinBorderSyncChanged)
+{
+    winPinBorderIdleTicks:=0
+    winPinBorder_setTimerInterval(winPinBorderActiveInterval)
+}
+else
+{
+    winPinBorderIdleTicks++
+    if(winPinBorderIdleTicks>=20)
+        winPinBorder_setTimerInterval(winPinBorderIdleInterval)
 }
 return

--- a/lib/lib_winPinBorder.ahk
+++ b/lib/lib_winPinBorder.ahk
@@ -13,11 +13,17 @@ global winPinBorderWidth:=6
 global winPinBorderSyncInterval:=0
 global winPinBorderIdleTicks:=0
 global winPinBorderActiveInterval:=15
-global winPinBorderIdleInterval:=50
+global winPinBorderIdleInterval:=100
 global winPinCustomSoundFile:=""
+global winPinBorderLocationHook:=0
+global winPinBorderLocationCallback:=0
+global winPinBorderEventSyncPending:=false
+global winPinBorderNewHwnd:=0
 
 winPinBorder_add(winId){
-    global winPinBorders, winPinBorderGuiNames, winPinBorderColor, winPinBorderSizes, winPinBorderPositions, winPinBorderVisibility, winPinBorderFrameMetrics, winPinBorderWinIds, winPinBorderWidth, winPinBorderActiveInterval, winPinBorderIdleInterval, winPinBorderIdleTicks
+    local
+    global winPinBorders, winPinBorderGuiNames, winPinBorderColor, winPinBorderSizes, winPinBorderPositions, winPinBorderVisibility, winPinBorderFrameMetrics, winPinBorderWinIds, winPinBorderWidth, winPinBorderActiveInterval, winPinBorderIdleInterval, winPinBorderIdleTicks, winPinBorderNewHwnd
+    local rect, thickness, borderHwnd, frameLeft, frameTop, frameWidth, frameHeight
 
     if(!IsObject(winPinBorders))
         winPinBorders:={}
@@ -40,7 +46,7 @@ winPinBorder_add(winId){
     if(winPinBorderActiveInterval="")
         winPinBorderActiveInterval:=15
     if(winPinBorderIdleInterval="")
-        winPinBorderIdleInterval:=50
+        winPinBorderIdleInterval:=100
     if(winPinBorderIdleTicks="")
         winPinBorderIdleTicks:=0
     winPinBorder_refreshSettings()
@@ -53,36 +59,34 @@ winPinBorder_add(winId){
     rect:=winPinBorder_getRect(winId)
     if(!IsObject(rect))
         return false
-    x:=rect.x
-    y:=rect.y
-    w:=rect.w
-    h:=rect.h
-    dpi:=rect.dpi
-    thickness:=Max(2, Round(winPinBorderWidth*dpi/96))
-
-    guiName:="WinPinBorder_" . Format("{:d}", winId+0)
-    Gui, %guiName%:New, +HwndborderHwnd -Caption +ToolWindow +AlwaysOnTop +E0x20 +E0x08000000
-    Gui, %guiName%:Color, %winPinBorderColor%
-
-    ; 将边框设为目标窗口的 owned window。Windows 会保证它位于目标窗口之上，
-    ; 同时把二者作为同一个 Z 顺序组处理，其他前景窗口可正常盖住整个组。
-    if(A_PtrSize=8)
-        DllCall("User32\SetWindowLongPtr", "Ptr", borderHwnd, "Int", -8, "Ptr", winId, "Ptr") ; GWLP_HWNDPARENT
-    if(A_PtrSize!=8)
-        DllCall("User32\SetWindowLong", "Ptr", borderHwnd, "Int", -8, "Ptr", winId, "Ptr")
-
-    showOptions:="NA x" . Format("{:d}", x) . " y" . Format("{:d}", y) . " w" . Format("{:d}", w) . " h" . Format("{:d}", h)
-    Gui, %guiName%:Show, %showOptions%
-    winPinBorder_setRegion(borderHwnd, w, h, thickness)
+    thickness:=rect.thickness
+    frameLeft:=rect.frameLeft
+    frameTop:=rect.frameTop
+    frameWidth:=rect.frameWidth
+    frameHeight:=rect.frameHeight
+    ; 与 PowerToys 一样，以 DWM 返回的可见窗口边界为基准，边框向外展开。
+    ; 内孔正好等于目标窗口的可见区域，因此不会压住窗口内容，也不会留下阴影间隙。
+    ; 当前边框由普通 GUI 背景色绘制，不能使用 WS_EX_NOREDIRECTIONBITMAP；
+    ; 否则 DWM 不会为窗口建立可见的重定向表面。
+    winPinBorderNewHwnd:=0
+    Gui, New, -Caption +ToolWindow +AlwaysOnTop +Disabled +E0x20 +HwndwinPinBorderNewHwnd
+    borderHwnd:=winPinBorderNewHwnd
+    Gui, Color, %winPinBorderColor%
+    ; 先让 AHK 完成底层窗口初始化，但保持隐藏；随后由 Win32 API 按物理像素显示。
+    Gui, Show, Hide x0 y0 w1 h1
 
     winPinBorders[winId]:=borderHwnd
-    winPinBorderGuiNames[winId]:=guiName
-    winPinBorderSizes[winId]:=w . "|" . h . "|" . thickness
-    winPinBorderPositions[winId]:=x . "|" . y . "|" . w . "|" . h
-    winPinBorderVisibility[winId]:=true
+    winPinBorderGuiNames[winId]:=borderHwnd
+    ; AHK 函数线程内对刚创建 GUI 的定位/显示可能不会立即落地。
+    ; 留空缓存并交给顶层同步标签完成首次定位、裁剪和显示。
+    winPinBorderSizes[winId]:=""
+    winPinBorderPositions[winId]:=""
+    winPinBorderVisibility[winId]:=false
     winPinBorderWinIds.Push(winId)
     winPinBorderIdleTicks:=0
+    winPinBorder_ensureEventHook()
     winPinBorder_setTimerInterval(winPinBorderActiveInterval)
+    SetTimer, winPinBorderEventSyncTimer, -1
     return true
 }
 
@@ -93,8 +97,7 @@ winPinBorder_remove(winId){
         return
 
     borderHwnd:=winPinBorders[winId]
-    guiName:=winPinBorderGuiNames[winId]
-    Gui, %guiName%:Destroy
+    DllCall("User32\DestroyWindow", "Ptr", borderHwnd)
 
     winPinBorders.Delete(winId)
     winPinBorderGuiNames.Delete(winId)
@@ -113,6 +116,7 @@ winPinBorder_remove(winId){
     {
         SetTimer, winPinBorderSyncTimer, Off
         winPinBorderSyncInterval:=0
+        winPinBorder_stopEventHook()
     }
 }
 
@@ -123,11 +127,56 @@ winPinBorder_setTimerInterval(interval){
         return
     winPinBorderSyncInterval:=interval
     if(interval>0)
-        SetTimer, winPinBorderSyncTimer, %interval%
+        SetTimer, winPinBorderSyncTimer, % interval
     else
         SetTimer, winPinBorderSyncTimer, Off
     if(interval>0)
         winPinBorderIdleTicks:=0
+}
+
+winPinBorder_ensureEventHook(){
+    global winPinBorderLocationHook, winPinBorderLocationCallback
+
+    if(winPinBorderLocationHook)
+        return true
+    if(!winPinBorderLocationCallback)
+        winPinBorderLocationCallback:=RegisterCallback("winPinBorder_winEventProc", "", 7)
+    if(!winPinBorderLocationCallback)
+        return false
+
+    ; EVENT_OBJECT_LOCATIONCHANGE。由系统在窗口移动/缩放时主动通知，
+    ; 避免单纯依赖 AHK 定时器造成边框落后一帧或数帧。
+    winPinBorderLocationHook:=DllCall("User32\SetWinEventHook", "UInt", 0x800B, "UInt", 0x800B, "Ptr", 0, "Ptr", winPinBorderLocationCallback, "UInt", 0, "UInt", 0, "UInt", 0, "Ptr")
+    return winPinBorderLocationHook ? true : false
+}
+
+winPinBorder_stopEventHook(){
+    global winPinBorderLocationHook
+
+    if(winPinBorderLocationHook)
+    {
+        DllCall("User32\UnhookWinEvent", "Ptr", winPinBorderLocationHook)
+        winPinBorderLocationHook:=0
+    }
+}
+
+winPinBorder_winEventProc(hWinEventHook, event, hwnd, idObject, idChild, eventThread, eventTime){
+    global winPinBorders, winPinBorderIdleTicks, winPinBorderEventSyncPending
+
+    ; OBJID_WINDOW=0、CHILDID_SELF=0。过滤光标和子控件的位置变化事件。
+    if(event!=0x800B || !hwnd || idObject!=0 || idChild!=0)
+        return
+    if(!IsObject(winPinBorders) || !winPinBorders.HasKey(hwnd))
+        return
+
+    ; AHK 回调线程内直接移动边框 GUI 可能被系统忽略。只投递一个立即执行的
+    ; 顶层定时任务，在目标窗口的位置消息处理完毕后同步边框。
+    winPinBorderIdleTicks:=0
+    if(!winPinBorderEventSyncPending)
+    {
+        winPinBorderEventSyncPending:=true
+        SetTimer, winPinBorderEventSyncTimer, -1
+    }
 }
 
 winPinBorder_parseColor(value){
@@ -160,6 +209,7 @@ winPinBorder_tryParseColor(value, ByRef normalizedColor){
 }
 
 winPinBorder_refreshSettings(){
+    static selectedBorderHwnd
     global CLSets, winPinBorderColor, winPinBorders, winPinBorderGuiNames
 
     if(!IsObject(winPinBorders))
@@ -177,8 +227,9 @@ winPinBorder_refreshSettings(){
     winPinBorderColor:=newColor
     for winId,borderHwnd in winPinBorders
     {
-        guiName:=winPinBorderGuiNames[winId]
-        Gui, %guiName%:Color, %winPinBorderColor%
+        selectedBorderHwnd:=borderHwnd
+        Gui, %selectedBorderHwnd%:Default
+        Gui, Color, %winPinBorderColor%
         DllCall("User32\RedrawWindow", "Ptr", borderHwnd, "Ptr", 0, "Ptr", 0, "UInt", 0x105)
     }
 }
@@ -213,9 +264,20 @@ winPin_playSound(isPinned, force:=false){
     return DllCall("Winmm\PlaySoundW", "WStr", unpinSoundFile, "Ptr", 0, "UInt", 0x20003)
 }
 
-winPinBorder_setRegion(borderHwnd, w, h, thickness){
-    outerRegion:=DllCall("Gdi32\CreateRectRgn", "Int", 0, "Int", 0, "Int", w, "Int", h, "Ptr")
-    innerRegion:=DllCall("Gdi32\CreateRectRgn", "Int", thickness, "Int", thickness, "Int", Max(thickness+1, w-thickness), "Int", Max(thickness+1, h-thickness), "Ptr")
+winPinBorder_setRegion(borderHwnd, w, h, thickness, cornerRadius:=0){
+    if(cornerRadius>0)
+    {
+        outerRadius:=cornerRadius+thickness
+        outerDiameter:=Max(2, 2*outerRadius)
+        innerDiameter:=Max(2, 2*cornerRadius)
+        outerRegion:=DllCall("Gdi32\CreateRoundRectRgn", "Int", 0, "Int", 0, "Int", w, "Int", h, "Int", outerDiameter, "Int", outerDiameter, "Ptr")
+        innerRegion:=DllCall("Gdi32\CreateRoundRectRgn", "Int", thickness, "Int", thickness, "Int", Max(thickness+1, w-thickness), "Int", Max(thickness+1, h-thickness), "Int", innerDiameter, "Int", innerDiameter, "Ptr")
+    }
+    else
+    {
+        outerRegion:=DllCall("Gdi32\CreateRectRgn", "Int", 0, "Int", 0, "Int", w, "Int", h, "Ptr")
+        innerRegion:=DllCall("Gdi32\CreateRectRgn", "Int", thickness, "Int", thickness, "Int", Max(thickness+1, w-thickness), "Int", Max(thickness+1, h-thickness), "Ptr")
+    }
 
     DllCall("Gdi32\CombineRgn", "Ptr", outerRegion, "Ptr", outerRegion, "Ptr", innerRegion, "Int", 4) ; RGN_DIFF
     if(!DllCall("User32\SetWindowRgn", "Ptr", borderHwnd, "Ptr", outerRegion, "Int", true))
@@ -235,10 +297,14 @@ winPinBorder_shouldShow(winId){
 
 winPinBorder_getRect(winId){
     static rectBuffer
-    global winPinBorderFrameMetrics
+    global winPinBorderFrameMetrics, winPinBorderWidth
 
     VarSetCapacity(rectBuffer, 16, 0)
-    if(!DllCall("User32\GetWindowRect", "Ptr", winId, "Ptr", &rectBuffer))
+    ; PowerToys 使用 DWMWA_EXTENDED_FRAME_BOUNDS：它排除了 Windows 10/11
+    ; 为缩放和阴影保留的不可见边距，比按系统指标估算更贴合实际窗口轮廓。
+    dwmResult:=DllCall("Dwmapi\DwmGetWindowAttribute", "Ptr", winId, "UInt", 9, "Ptr", &rectBuffer, "UInt", 16, "Int")
+    usedDwmBounds:=(dwmResult=0)
+    if(!usedDwmBounds && !DllCall("User32\GetWindowRect", "Ptr", winId, "Ptr", &rectBuffer))
         return false
     rectX:=NumGet(rectBuffer, 0, "Int")
     rectY:=NumGet(rectBuffer, 4, "Int")
@@ -251,37 +317,69 @@ winPinBorder_getRect(winId){
     if(!dpi)
         dpi:=A_ScreenDPI
 
-    ; Win10/11 会在可缩放窗口四周保留一圈不可见的调整边距。
-    ; 按系统边框指标向内修正，避免可见边框与窗口之间出现空隙。
-    windowStyle:=DllCall("User32\GetWindowLongPtr", "Ptr", winId, "Int", -16, "Ptr")
-    if(windowStyle & 0x40000) ; WS_THICKFRAME
+    ; 仅在 DWM API 不可用时保留原来的系统指标回退。
+    if(!usedDwmBounds)
     {
-        if(!winPinBorderFrameMetrics.HasKey(dpi))
+        windowStyle:=DllCall("User32\GetWindowLongPtr", "Ptr", winId, "Int", -16, "Ptr")
+        if(windowStyle & 0x40000) ; WS_THICKFRAME
         {
-            frameX:=DllCall("User32\GetSystemMetricsForDpi", "Int", 32, "UInt", dpi, "Int")
-            frameY:=DllCall("User32\GetSystemMetricsForDpi", "Int", 33, "UInt", dpi, "Int")
-            padded:=DllCall("User32\GetSystemMetricsForDpi", "Int", 92, "UInt", dpi, "Int")
-            winPinBorderFrameMetrics[dpi]:={x:frameX+padded, y:frameY+padded}
-        }
-        frameX:=winPinBorderFrameMetrics[dpi].x
-        frameY:=winPinBorderFrameMetrics[dpi].y
-        if(frameX>0 && frameY>0)
-        {
-            rectX+=frameX
-            rectW-=2*frameX
-            rectH-=frameY
+            if(!winPinBorderFrameMetrics.HasKey(dpi))
+            {
+                frameX:=DllCall("User32\GetSystemMetricsForDpi", "Int", 32, "UInt", dpi, "Int")
+                frameY:=DllCall("User32\GetSystemMetricsForDpi", "Int", 33, "UInt", dpi, "Int")
+                padded:=DllCall("User32\GetSystemMetricsForDpi", "Int", 92, "UInt", dpi, "Int")
+                winPinBorderFrameMetrics[dpi]:={x:frameX+padded, y:frameY+padded}
+            }
+            frameX:=winPinBorderFrameMetrics[dpi].x
+            frameY:=winPinBorderFrameMetrics[dpi].y
+            if(frameX>0 && frameY>0)
+            {
+                rectX+=frameX
+                rectW-=2*frameX
+                rectH-=frameY
+            }
         }
     }
 
     if(rectW<=0 || rectH<=0)
         return false
-    return {x:rectX, y:rectY, w:rectW, h:rectH, dpi:dpi}
+    cornerRadius:=winPinBorder_getCornerRadius(winId, dpi)
+    thickness:=Max(2, Round(winPinBorderWidth*dpi/96))
+    frameLeft:=rectX-thickness
+    frameTop:=rectY-thickness
+    frameWidth:=rectW+2*thickness
+    frameHeight:=rectH+2*thickness
+    return {"left":rectX, "top":rectY, "width":rectW, "height":rectH, "dpi":dpi, "cornerRadius":cornerRadius
+        , "thickness":thickness, "frameLeft":frameLeft, "frameTop":frameTop, "frameWidth":frameWidth, "frameHeight":frameHeight}
+}
+
+winPinBorder_getCornerRadius(winId, dpi){
+    local
+    local preference, logicalRadius
+
+    if(DllCall("User32\IsZoomed", "Ptr", winId))
+        return 0
+
+    preference:=0
+    ; DWMWA_WINDOW_CORNER_PREFERENCE=33，仅 Windows 11 支持。
+    dwmResult:=DllCall("Dwmapi\DwmGetWindowAttribute", "Ptr", winId, "UInt", 33, "UInt*", preference, "UInt", 4, "Int")
+    if(dwmResult)
+        return 0
+    if(preference=1) ; DWMWCP_DONOTROUND
+        return 0
+    logicalRadius:=preference=3 ? 4 : 8 ; ROUND_SMALL / DEFAULT or ROUND
+    return Max(1, Round(logicalRadius*dpi/96))
 }
 
 winPinBorder_show(borderHwnd, show){
     showCommand:=show ? 8 : 0 ; SW_SHOWNA / SW_HIDE
     DllCall("ShowWindow", "Ptr", borderHwnd, "Int", showCommand)
 }
+
+winPinBorderEventSyncTimer:
+winPinBorderEventSyncPending:=false
+Gosub, winPinBorderSyncTimer
+return
 
 winPinBorderSyncTimer:
 winPinBorderSyncChanged:=false
@@ -323,33 +421,33 @@ while(winPinBorderSyncIndex>=1)
         winPinBorderSyncIndex--
         continue
     }
+    winPinBorderSyncThickness:=winPinBorderSyncRect.thickness
+    winPinBorderSyncRadius:=winPinBorderSyncRect.cornerRadius
+    winPinBorderSyncLeft:=winPinBorderSyncRect.frameLeft
+    winPinBorderSyncTop:=winPinBorderSyncRect.frameTop
+    winPinBorderSyncWidth:=winPinBorderSyncRect.frameWidth
+    winPinBorderSyncHeight:=winPinBorderSyncRect.frameHeight
+    winPinBorderSyncPositionKey:=winPinBorderSyncLeft . "|" . winPinBorderSyncTop . "|" . winPinBorderSyncWidth . "|" . winPinBorderSyncHeight
 
-    winPinBorderSyncX:=winPinBorderSyncRect.x
-    winPinBorderSyncY:=winPinBorderSyncRect.y
-    winPinBorderSyncW:=winPinBorderSyncRect.w
-    winPinBorderSyncH:=winPinBorderSyncRect.h
-    winPinBorderSyncDpi:=winPinBorderSyncRect.dpi
-    winPinBorderSyncThickness:=Max(2, Round(winPinBorderWidth*winPinBorderSyncDpi/96))
-
-    winPinBorderSyncPositionKey:=winPinBorderSyncX . "|" . winPinBorderSyncY . "|" . winPinBorderSyncW . "|" . winPinBorderSyncH
     if(winPinBorderPositions[winPinBorderSyncWinId]!=winPinBorderSyncPositionKey)
     {
-        DllCall("User32\MoveWindow", "Ptr", winPinBorderSyncHwnd+0, "Int", winPinBorderSyncX, "Int", winPinBorderSyncY, "Int", winPinBorderSyncW, "Int", winPinBorderSyncH, "Int", true)
-        winPinBorderPositions[winPinBorderSyncWinId]:=winPinBorderSyncPositionKey
+        if(DllCall("User32\SetWindowPos", "Ptr", winPinBorderSyncHwnd, "Ptr", -1, "Int", winPinBorderSyncLeft, "Int", winPinBorderSyncTop, "Int", winPinBorderSyncWidth, "Int", winPinBorderSyncHeight, "UInt", 0x10)) ; HWND_TOPMOST, SWP_NOACTIVATE
+        {
+            winPinBorderPositions[winPinBorderSyncWinId]:=winPinBorderSyncPositionKey
+            winPinBorderSyncChanged:=true
+        }
+    }
+    winPinBorderSyncSizeKey:=winPinBorderSyncWidth . "|" . winPinBorderSyncHeight . "|" . winPinBorderSyncThickness . "|" . winPinBorderSyncRadius
+    if(winPinBorderSizes[winPinBorderSyncWinId]!=winPinBorderSyncSizeKey)
+    {
+        winPinBorder_setRegion(winPinBorderSyncHwnd, winPinBorderSyncWidth, winPinBorderSyncHeight, winPinBorderSyncThickness, winPinBorderSyncRadius)
+        winPinBorderSizes[winPinBorderSyncWinId]:=winPinBorderSyncSizeKey
         winPinBorderSyncChanged:=true
     }
     if(!winPinBorderVisibility[winPinBorderSyncWinId])
     {
-        DllCall("User32\ShowWindow", "Ptr", winPinBorderSyncHwnd+0, "Int", 8)
+        DllCall("User32\ShowWindow", "Ptr", winPinBorderSyncHwnd, "Int", 8)
         winPinBorderVisibility[winPinBorderSyncWinId]:=true
-        winPinBorderSyncChanged:=true
-    }
-
-    winPinBorderSyncSizeKey:=winPinBorderSyncW . "|" . winPinBorderSyncH . "|" . winPinBorderSyncThickness
-    if(winPinBorderSizes[winPinBorderSyncWinId]!=winPinBorderSyncSizeKey)
-    {
-        winPinBorder_setRegion(winPinBorderSyncHwnd, winPinBorderSyncW, winPinBorderSyncH, winPinBorderSyncThickness)
-        winPinBorderSizes[winPinBorderSyncWinId]:=winPinBorderSyncSizeKey
         winPinBorderSyncChanged:=true
     }
     winPinBorderSyncIndex--

--- a/lib/lib_winPinBorder.ahk
+++ b/lib/lib_winPinBorder.ahk
@@ -1,0 +1,209 @@
+; 为 CapsLock+ 置顶的窗口绘制持续可见的边框。
+; 边框由一个中间镂空、不激活、鼠标穿透的工具窗口组成，不会影响目标窗口操作。
+
+global winPinBorders:={}
+global winPinBorderSizes:={}
+global winPinBorderPositions:={}
+global winPinBorderWinIds:=[]
+global winPinBorderColor:="00ADEF"
+global winPinBorderWidth:=6
+
+winPinBorder_add(winId){
+    global winPinBorders, winPinBorderColor, winPinBorderSizes, winPinBorderPositions, winPinBorderWinIds, winPinBorderWidth
+
+    if(!IsObject(winPinBorders))
+        winPinBorders:={}
+    if(!IsObject(winPinBorderSizes))
+        winPinBorderSizes:={}
+    if(!IsObject(winPinBorderPositions))
+        winPinBorderPositions:={}
+    if(!IsObject(winPinBorderWinIds))
+        winPinBorderWinIds:=[]
+    if(winPinBorderColor="")
+        winPinBorderColor:="00ADEF"
+    if(winPinBorderWidth="")
+        winPinBorderWidth:=6
+    if(!DllCall("IsWindow", "Ptr", winId))
+        return false
+
+    if(winPinBorders.HasKey(winId))
+        return true
+
+    rect:=winPinBorder_getRect(winId)
+    if(!IsObject(rect))
+        return false
+    x:=rect.x
+    y:=rect.y
+    w:=rect.w
+    h:=rect.h
+    dpi:=DllCall("User32\GetDpiForWindow", "Ptr", winId, "UInt")
+    if(!dpi)
+        dpi:=A_ScreenDPI
+    thickness:=Max(2, Round(winPinBorderWidth*dpi/96))
+
+    guiName:="WinPinBorder_" . winId
+    Gui, %guiName%:New, +HwndborderHwnd -Caption +ToolWindow +AlwaysOnTop +E0x20 +E0x08000000
+    Gui, %guiName%:Color, %winPinBorderColor%
+
+    ; 将边框设为目标窗口的 owned window。Windows 会保证它位于目标窗口之上，
+    ; 同时把二者作为同一个 Z 顺序组处理，其他前景窗口可正常盖住整个组。
+    if(A_PtrSize=8)
+        DllCall("User32\SetWindowLongPtr", "Ptr", borderHwnd, "Int", -8, "Ptr", winId, "Ptr") ; GWLP_HWNDPARENT
+    if(A_PtrSize!=8)
+        DllCall("User32\SetWindowLong", "Ptr", borderHwnd, "Int", -8, "Ptr", winId, "Ptr")
+
+    Gui, %guiName%:Show, NA x%x% y%y% w%w% h%h%
+    winPinBorder_setRegion(borderHwnd, w, h, thickness)
+
+    winPinBorders[winId]:=borderHwnd
+    winPinBorderSizes[winId]:=w . "|" . h . "|" . thickness
+    winPinBorderPositions[winId]:=x . "|" . y . "|" . w . "|" . h
+    winPinBorderWinIds.Push(winId)
+    SetTimer, winPinBorderSyncTimer, 10
+    return true
+}
+
+winPinBorder_remove(winId){
+    global winPinBorders, winPinBorderSizes, winPinBorderPositions, winPinBorderWinIds
+
+    if(!winPinBorders.HasKey(winId))
+        return
+
+    borderHwnd:=winPinBorders[winId]
+    Gui, %borderHwnd%:Destroy
+
+    winPinBorders.Delete(winId)
+    winPinBorderSizes.Delete(winId)
+    winPinBorderPositions.Delete(winId)
+    Loop, % winPinBorderWinIds.Length()
+    {
+        if(winPinBorderWinIds[A_Index]=winId)
+        {
+            winPinBorderWinIds.RemoveAt(A_Index)
+            break
+        }
+    }
+    if(!winPinBorders.Count())
+        SetTimer, winPinBorderSyncTimer, Off
+}
+
+winPinBorder_setRegion(borderHwnd, w, h, thickness){
+    outerRegion:=DllCall("Gdi32\CreateRectRgn", "Int", 0, "Int", 0, "Int", w, "Int", h, "Ptr")
+    innerRegion:=DllCall("Gdi32\CreateRectRgn", "Int", thickness, "Int", thickness, "Int", Max(thickness+1, w-thickness), "Int", Max(thickness+1, h-thickness), "Ptr")
+
+    DllCall("Gdi32\CombineRgn", "Ptr", outerRegion, "Ptr", outerRegion, "Ptr", innerRegion, "Int", 4) ; RGN_DIFF
+    if(!DllCall("User32\SetWindowRgn", "Ptr", borderHwnd, "Ptr", outerRegion, "Int", true))
+        DllCall("Gdi32\DeleteObject", "Ptr", outerRegion)
+    DllCall("Gdi32\DeleteObject", "Ptr", innerRegion)
+}
+
+winPinBorder_shouldShow(winId){
+    if(!DllCall("IsWindowVisible", "Ptr", winId))
+        return false
+
+    if(DllCall("User32\IsIconic", "Ptr", winId))
+        return false
+
+    return true
+}
+
+winPinBorder_getRect(winId){
+    static rectBuffer
+
+    VarSetCapacity(rectBuffer, 16, 0)
+    if(!DllCall("User32\GetWindowRect", "Ptr", winId, "Ptr", &rectBuffer))
+        return false
+    rectX:=NumGet(rectBuffer, 0, "Int")
+    rectY:=NumGet(rectBuffer, 4, "Int")
+    rectW:=NumGet(rectBuffer, 8, "Int")-rectX
+    rectH:=NumGet(rectBuffer, 12, "Int")-rectY
+    if(rectW<=0 || rectH<=0)
+        return false
+
+    ; Win10/11 会在可缩放窗口四周保留一圈不可见的调整边距。
+    ; 按系统边框指标向内修正，避免可见边框与窗口之间出现空隙。
+    windowStyle:=DllCall("User32\GetWindowLongPtr", "Ptr", winId, "Int", -16, "Ptr")
+    if(windowStyle & 0x40000) ; WS_THICKFRAME
+    {
+        dpi:=DllCall("User32\GetDpiForWindow", "Ptr", winId, "UInt")
+        if(!dpi)
+            dpi:=A_ScreenDPI
+        frameX:=DllCall("User32\GetSystemMetricsForDpi", "Int", 32, "UInt", dpi, "Int")
+        frameY:=DllCall("User32\GetSystemMetricsForDpi", "Int", 33, "UInt", dpi, "Int")
+        padded:=DllCall("User32\GetSystemMetricsForDpi", "Int", 92, "UInt", dpi, "Int")
+        if(frameX>0 && frameY>0)
+        {
+            frameX+=padded
+            frameY+=padded
+            rectX+=frameX
+            rectW-=2*frameX
+            rectH-=frameY
+        }
+    }
+
+    if(rectW<=0 || rectH<=0)
+        return false
+    return {x:rectX, y:rectY, w:rectW, h:rectH}
+}
+
+winPinBorder_show(borderHwnd, show){
+    showCommand:=show ? 8 : 0 ; SW_SHOWNA / SW_HIDE
+    DllCall("ShowWindow", "Ptr", borderHwnd, "Int", showCommand)
+}
+
+winPinBorderSyncTimer:
+winPinBorderSyncIndex:=winPinBorderWinIds.Length()
+while(winPinBorderSyncIndex>=1)
+{
+    winPinBorderSyncWinId:=winPinBorderWinIds[winPinBorderSyncIndex]
+    if(!DllCall("IsWindow", "Ptr", winPinBorderSyncWinId))
+    {
+        winPinBorder_remove(winPinBorderSyncWinId)
+        winPinBorderSyncIndex--
+        continue
+    }
+
+    winPinBorderSyncExStyle:=DllCall("User32\GetWindowLongPtr", "Ptr", winPinBorderSyncWinId, "Int", -20, "Ptr")
+    if(!(winPinBorderSyncExStyle & 0x8))
+    {
+        winPinBorder_remove(winPinBorderSyncWinId)
+        winPinBorderSyncIndex--
+        continue
+    }
+
+    winPinBorderSyncHwnd:=winPinBorders[winPinBorderSyncWinId]
+    winPinBorderSyncRect:=winPinBorder_getRect(winPinBorderSyncWinId)
+    if(!winPinBorder_shouldShow(winPinBorderSyncWinId) || !IsObject(winPinBorderSyncRect))
+    {
+        DllCall("User32\ShowWindow", "Ptr", winPinBorderSyncHwnd, "Int", 0)
+        winPinBorderSyncIndex--
+        continue
+    }
+
+    winPinBorderSyncX:=winPinBorderSyncRect.x
+    winPinBorderSyncY:=winPinBorderSyncRect.y
+    winPinBorderSyncW:=winPinBorderSyncRect.w
+    winPinBorderSyncH:=winPinBorderSyncRect.h
+    winPinBorderSyncDpi:=DllCall("User32\GetDpiForWindow", "Ptr", winPinBorderSyncWinId, "UInt")
+    if(!winPinBorderSyncDpi)
+        winPinBorderSyncDpi:=A_ScreenDPI
+    winPinBorderSyncThickness:=Max(2, Round(winPinBorderWidth*winPinBorderSyncDpi/96))
+
+    winPinBorderSyncPositionKey:=winPinBorderSyncX . "|" . winPinBorderSyncY . "|" . winPinBorderSyncW . "|" . winPinBorderSyncH
+    if(winPinBorderPositions[winPinBorderSyncWinId]!=winPinBorderSyncPositionKey)
+    {
+        DllCall("User32\MoveWindow", "Ptr", winPinBorderSyncHwnd+0, "Int", winPinBorderSyncX, "Int", winPinBorderSyncY, "Int", winPinBorderSyncW, "Int", winPinBorderSyncH, "Int", true)
+        winPinBorderPositions[winPinBorderSyncWinId]:=winPinBorderSyncPositionKey
+    }
+    if(!DllCall("User32\IsWindowVisible", "Ptr", winPinBorderSyncHwnd+0))
+        DllCall("User32\ShowWindow", "Ptr", winPinBorderSyncHwnd+0, "Int", 8)
+
+    winPinBorderSyncSizeKey:=winPinBorderSyncW . "|" . winPinBorderSyncH . "|" . winPinBorderSyncThickness
+    if(winPinBorderSizes[winPinBorderSyncWinId]!=winPinBorderSyncSizeKey)
+    {
+        winPinBorder_setRegion(winPinBorderSyncHwnd, winPinBorderSyncW, winPinBorderSyncH, winPinBorderSyncThickness)
+        winPinBorderSizes[winPinBorderSyncWinId]:=winPinBorderSyncSizeKey
+    }
+    winPinBorderSyncIndex--
+}
+return

--- a/userAHK/main.ahk
+++ b/userAHK/main.ahk
@@ -17,6 +17,20 @@ keyFunc_example1(){
   msgbox, example1
 }
 
+keyFunc_qbarListary(){
+    KeyWait, CapsLock
+    selText:=getSelText()
+    SendInput, !{Space}
+    WinWait, ahk_exe Listary.exe, , 0.5
+    if(selText!="")
+    {
+        selText:="gg " . selText
+        SendInput, %selText%
+        SendInput, {Home}
+    }
+    return
+}
+
 ; end demo
 
 

--- a/userAHK/main.ahk
+++ b/userAHK/main.ahk
@@ -17,17 +17,69 @@ keyFunc_example1(){
   msgbox, example1
 }
 
-keyFunc_qbarListary(){
+keyFunc_qbarExternalApp(){
+    global CLSets
     KeyWait, CapsLock
-    selText:=getSelText()
-    SendInput, !{Space}
-    WinWait, ahk_exe Listary.exe, , 0.5
-    if(selText!="")
+    externalPath:=""
+    if(IsObject(CLSets) && IsObject(CLSets.Global))
     {
-        selText:="gg " . selText
-        SendInput, %selText%
-        SendInput, {Home}
+        externalPath:=Trim(CLSets.Global.externalAppPath)
+        if(externalPath="")
+            externalPath:=Trim(CLSets.Global.listaryPath)
     }
+    if(externalPath="")
+    {
+        message:="Set the external application path in Settings > Qbar first."
+        MsgBox, 0x40030, CapsLock+, %message%
+        return
+    }
+    if(!FileExist(externalPath))
+    {
+        message:="The external application path does not exist. Configure it again."
+        MsgBox, 0x40030, CapsLock+, %message%
+        return
+    }
+    externalExeName:=""
+    SplitPath, externalPath, externalExeName
+    StringLower, externalExeNameLower, externalExeName
+    isListary:=externalExeNameLower="listary.exe"
+    if(isListary)
+        selText:=getSelText()
+    Process, Exist, %externalExeName%
+    if(!ErrorLevel)
+    {
+        quotedExternalPath:="""" . externalPath . """"
+        Run, %quotedExternalPath%,, UseErrorLevel
+        if(ErrorLevel)
+        {
+            message:="The external application could not be started. Check its path."
+            MsgBox, 0x40030, CapsLock+, %message%
+            return
+        }
+        Sleep, 300
+    }
+    if(isListary)
+    {
+        SendInput, !{Space}
+        WinWait, ahk_exe %externalExeName%, , 0.8
+        if(selText!="")
+        {
+            selText:="gg " . selText
+            SendInput, %selText%
+            SendInput, {Home}
+        }
+    }
+    else
+    {
+        WinWait, ahk_exe %externalExeName%, , 1.5
+        WinActivate, ahk_exe %externalExeName%
+    }
+    return
+}
+
+; Keep the legacy function name working for existing configuration files.
+keyFunc_qbarListary(){
+    keyFunc_qbarExternalApp()
     return
 }
 


### PR DESCRIPTION
- 新增现代化图形设置界面，可从托盘菜单打开。设置界面支持常规选项、快捷键方案、置顶窗口、Qbar 外部程序和常用短语配置，同时保留打开高级配置文件的入口。
- 为置顶窗口新增醒目的**外边框和置顶/取消置顶提示音**；支持自定义边框颜色、开关提示音及选择 WAV 音效。（借鉴powertoys）
- 改进置顶边框的定位与渲染，使其能适配窗口移动、缩放、最小化、关闭、DPI 和圆角变化，并通过事件监听及动态刷新间隔降低空闲开销。